### PR TITLE
BUGFIX: warning when png

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6879,7 +6879,12 @@ class TCPDF {
 					$file = $tfile;
 				}
 			}
-			if (($imsize = @getimagesize($file)) === FALSE) {
+			
+			$imsize = false;
+			if (@file_exists($file)){
+				$imsize = getimagesize($file);
+			}
+			if($imsize === false){
 				if (in_array($file, $this->imagekeys)) {
 					// get existing image data
 					$info = $this->getImageBuffer($file);


### PR DESCRIPTION
When adding a `png` the two cache calls throw warnings currently

I'm converting all errors/warnings to exception

```
2014-11-03T10:40:12+01:00 WARN (4): exception 'ErrorException' with message 'getimagesize(....\data\cache\tcpdf__tcpdf_imgmask_alpha_4a927e302242781011473e99c88d536b): failed to open stream: No such file or directory, URI: /changeover/report/general, Referrer: http://.../changeover/product/select, Username: degjea' in ...\vendor\tecnick.com\tcpdf\tcpdf.php:6882
Stack trace:
#0 [internal function]: Logger\Logger::Logger\{closure}(2, 'getimagesize(D:...', 'D:\Zend\Apache2...', 6882, Array)
#1 ...\vendor\tecnick.com\tcpdf\tcpdf.php(6882): getimagesize('D:\Zend\Apache2...')
#2 ...\vendor\tecnick.com\tcpdf\tcpdf.php(7035): TCPDF->Image('D:\Zend\Apache2...', 10, 105.760416, 6, 6, 'PNG', '', '', false, 300, '', true, false)

```
