### PR TITLE
Fix calling protected method in register_shutdown_function.

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -1985,7 +1985,7 @@ class TCPDF {
 		$this->custom_xmp = '';
 		// Call cleanup method after script execution finishes or exit() is called.
 		// NOTE: This will not be executed if the process is killed with a SIGTERM or SIGKILL signal.
-		register_shutdown_function(array($this, '_destroyAll'));
+		register_shutdown_function(array($this, '_destroy'), true);
 	}
 
 	/**


### PR DESCRIPTION
Now it rase Exception.

<code>(Registered shutdown functions) Unable to call TCPDF::_destroyAll() - function does not exist</code>
Best way use:
<code>register_shutdown_function(array($this, '_destroy'), true);</code>
