### PR TITLE
Use stream_is_local instead of limit to file://

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -2434,7 +2434,7 @@ class TCPDF_STATIC {
 	public static function fopenLocal($filename, $mode) {
 		if (strpos($filename, '://') === false) {
 			$filename = 'file://'.$filename;
-		} elseif (strpos($filename, 'file://') !== 0) {
+		} elseif (stream_is_local($filename) !== true) {
 			return false;
 		}
 		return fopen($filename, $mode);


### PR DESCRIPTION
Checking for `file://` limits a lot the possibilities, and it is not totally safe: built-in function is far more reliable.

The main reason for this commit is to allow the use of virtual local stream wrapper in unit-tested project, like [vfsStream](https://github.com/mikey179/vfsStream), in order to not touch real filesystem while testing the creation of PDF with this third-party library.