### PR TITLE
Added check for if it's same page. To prevent starting on ...

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -19427,8 +19427,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 				$prev_page = $this->page;
 				$this->setPage($dom[($dom[$key]['parent'])]['endpage']);
 				if ($this->num_columns > 1) {
-					if ((($this->current_column == 0) AND ($dom[($dom[$key]['parent'])]['endcolumn'] == ($this->num_columns - 1)))
-						OR (($this->current_column == $dom[($dom[$key]['parent'])]['endcolumn']) AND ($prev_page < $this->page))) {
+					if (((($this->current_column == 0) AND ($dom[($dom[$key]['parent'])]['endcolumn'] == ($this->num_columns - 1)) AND ($prev_page < $this->page))
+						OR (($this->current_column == $dom[($dom[$key]['parent'])]['endcolumn']))) AND ($prev_page < $this->page)) {
 						// page jump
 						$this->selectColumn(0);
 						$dom[($dom[$key]['parent'])]['endcolumn'] = 0;


### PR DESCRIPTION
...the same page again. Checked this against bug report 948 and 951 where changes to the table methods were done. Also checked all current examples.

This fixed an issue I had were sometime the Table of Content would start on the same page again. It simply skipped the page break. And wrong "second" page on top of the "first" page.