### PR TITLE
Avoid error with getimagesize when file URI contains a space

### DIFF
--- a/include/tcpdf_images.php
+++ b/include/tcpdf_images.php
@@ -160,6 +160,7 @@ class TCPDF_IMAGES {
 	 * @public static
 	 */
 	public static function _parsejpeg($file) {
+		$file = str_replace(' ', '%20', $file);
 		$a = getimagesize($file);
 		if (empty($a)) {
 			//Missing or incorrect image file


### PR DESCRIPTION
When a remote file has a space in the URL, there's an error because getimagesize requires the space to be encoded to `%20`.

The error message is `failed to open stream: HTTP request failed! HTTP/1.1 505 HTTP Version not supported`.

This pull request fixes it.