### PR TITLE
Unneeded set of y position to old value, added the possibility to again create anchor links within the pdf

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -18649,7 +18649,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 		$this->lispacer = $prev_lispacer;
 		if ($ln AND (!($cell AND ($dom[$key-1]['value'] == 'table')))) {
 			$this->Ln($this->lasth);
-			if ($this->y < $maxbottomliney) {
+			if ($this->y < $maxbottomliney && $startlinepage == $this->page) {
 				$this->y = $maxbottomliney;
 			}
 		}

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -10362,7 +10362,7 @@ class TCPDF {
 	 * @public
 	 */
 	public function addHtmlLink($url, $name, $fill=false, $firstline=false, $color='', $style=-1, $firstblock=false) {
-		if (isset($url[1]) AND ($url[0] == '#')) {
+		if (isset($url[1]) AND ($url[0] == '#') AND is_numeric($url[1])) {
 			// convert url to internal link
 			$lnkdata = explode(',', $url);
 			if (isset($lnkdata[0]) ) {

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -18649,7 +18649,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 		$this->lispacer = $prev_lispacer;
 		if ($ln AND (!($cell AND ($dom[$key-1]['value'] == 'table')))) {
 			$this->Ln($this->lasth);
-			if ($this->y < $maxbottomliney && $startlinepage == $this->page) {
+			if ($this->y < $maxbottomliney AND $startlinepage == $this->page) {
 				$this->y = $maxbottomliney;
 			}
 		}


### PR DESCRIPTION
with <a href="destination_name">Link text</a>... This has been broken for quite a while. Recently upgraded from 6.0.037 to 6.2.6. Just noticed that the links werent working anymore in the pdf.