### PR TITLE
Minor mod to PNG parsing

### DIFF
--- a/include/tcpdf_images.php
+++ b/include/tcpdf_images.php
@@ -289,8 +289,8 @@ class TCPDF_IMAGES {
 		$trns = '';
 		$data = '';
 		$icc = false;
+		$n = TCPDF_STATIC::_freadint($f);
 		do {
-			$n = TCPDF_STATIC::_freadint($f);
 			$type = fread($f, 4);
 			if ($type == 'PLTE') {
 				// read palette
@@ -338,6 +338,7 @@ class TCPDF_IMAGES {
 			} else {
 				TCPDF_STATIC::rfread($f, $n + 4);
 			}
+			$n = TCPDF_STATIC::_freadint($f);
 		} while ($n);
 		if (($colspace == 'Indexed') AND (empty($pal))) {
 			// Missing palette


### PR DESCRIPTION
Minor mod to main loop in _parsepng().

I encountered a PNG file, which I had just created dynamically with GD library, that had a zero byte IDAT block. According to pngcheck, this is OK (see output below). However, _parsepng() called TCPDF_STATIC::rfread() with a length of zero, which subsequently called fread() with a length of zero, which threw an error because it won't accept a length of zero.

A minor modification to the main loop in _parsepng() fixed this issue.

Output of pngcheck is below:

    File: test.png (32873 bytes)
      chunk IHDR at offset 0x0000c, length 13
        1200 x 284 image, 24-bit RGB, non-interlaced
      chunk IDAT at offset 0x00025, length 8192
        zlib: deflated, 32K window, default compression
      chunk IDAT at offset 0x02031, length 8192
      chunk IDAT at offset 0x0403d, length 8192
      chunk IDAT at offset 0x06049, length 8192
      chunk IDAT at offset 0x08055, length 0
      chunk IEND at offset 0x08061, length 0
    No errors detected in test.png (7 chunks, 96.8% compression).

DISCLAIMER: I have not read the PNG file spec, so I don't know if GD library is technically doing something illegal and pngcheck is just not flagging it.