### PR TITLE
Fixing warning + using cache

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6847,15 +6847,19 @@ class TCPDF {
 					$file = $tfile;
 				}
 			}
-			if (($imsize = @getimagesize($file)) === FALSE) {
-				if (in_array($file, $this->imagekeys)) {
-					// get existing image data
-					$info = $this->getImageBuffer($file);
-					$imsize = array($info['w'], $info['h']);
-				} elseif (strpos($file, '__tcpdf_'.$this->file_id.'_img') === FALSE) {
-					$imgdata = TCPDF_STATIC::fileGetContents($file);
-				}
+			
+			if (in_array($file, $this->imagekeys)) {
+			    // get existing image data
+			    $info = $this->getImageBuffer($file);
+			    $imsize = array($info['w'], $info['h']);
+			} else{
+			    $imsize = @getimagesize($file);
+			    
+			    if($imsize === false){
+			        $imgdata = TCPDF_STATIC::fileGetContents($file);
+			    }
 			}
+
 		}
 		if (!empty($imgdata)) {
 			// copy image to cache


### PR DESCRIPTION
2015-09-01T10:58:53+02:00 WARN (4): exception 'ErrorException' with message '
 > MSG: getimagesize(D:\wap\htdocs\lisp.prestagroup.com\data\cache\tcpdf__tcpdf_imgmask_plain_d2936e64b83af2c88602d2e6f0aa065a): failed to open stream: No such file or directory


' in D:\wap\htdocs\lisp.prestagroup.com\vendor\tecnick.com\tcpdf\tcpdf.php:6894
Stack trace:
#0 [internal function]: Logger\Logger::Logger\{closure}(2, 'getimagesize(D:...', 'D:\\wap\\htdocs\\l...', 6894, Array)
#1 D:\wap\htdocs\lisp.prestagroup.com\vendor\tecnick.com\tcpdf\tcpdf.php(6894): getimagesize('D:\\wap\\htdocs\\l...')
#2 D:\wap\htdocs\lisp.prestagroup.com\vendor\tecnick.com\tcpdf\tcpdf.php(7049): TCPDF->Image('D:\\wap\\htdocs\\l...', 188.90909090909, 108.44436066667, 6, 6, '', '', 'L', false, 300, '', false, 2)
