### PR TITLE
Use standardized license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type": "library",
 	"description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
 	"keywords": ["PDF","tcpdf","PDFD32000-2008","qrcode","datamatrix","pdf417","barcodes"],
-	"license": "LGPLv3",
+	"license": "LGPL-3.0",
 	"authors": [
 	{
 		"name": "Nicola Asuni",


### PR DESCRIPTION
SPDX has standardized the license identifiers to avoid confusions and allow tool-assisted license checks
https://spdx.org/licenses/