### PR TITLE
Fix composer.json validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,10 @@
 {
 	"name": "tecnickcom/tcpdf",
-	"version": "6.2.12",
 	"homepage": "http://www.tcpdf.org/",
 	"type": "library",
 	"description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
 	"keywords": ["PDF","tcpdf","PDFD32000-2008","qrcode","datamatrix","pdf417","barcodes"],
-	"license": "LGPLv3",
+	"license": "LGPL-3.0",
 	"authors": [
 	{
 		"name": "Nicola Asuni",


### PR DESCRIPTION
- License "LGPLv3" is not a valid SPDX license identifier, see http://www.spdx.org/licenses/ if you use an open license. If the software is closed-source, you may use "proprietary" as license.
- The version field is present, it is recommended to leave it out if the package is published on Packagist.