### PR TITLE
Changed getimagesize escaping the errors

### DIFF
--- a/include/tcpdf_images.php
+++ b/include/tcpdf_images.php
@@ -168,7 +168,7 @@ class TCPDF_IMAGES {
 				$file = $tfile;
 			}
 		}
-		$a = getimagesize($file);
+		$a = @getimagesize($file);
 		if (empty($a)) {
 			//Missing or incorrect image file
 			return false;


### PR DESCRIPTION
You will get errors when it is an external url, so escape it.

`Warning: getimagesize(): php_network_getaddresses: getaddrinfo failed`