### PR TITLE
Various minor SVG rendering fixes

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -22906,10 +22906,14 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 		// sets the character data handler function for the XML parser
 		xml_set_character_data_handler($this->parser, 'segSVGContentHandler');
 		// start parsing an XML document
-		if (!xml_parse($this->parser, $svgdata)) {
-			$error_message = sprintf('SVG Error: %s at line %d', xml_error_string(xml_get_error_code($this->parser)), xml_get_current_line_number($this->parser));
-			$this->Error($error_message);
+		$fh = fopen($file, 'r');
+		while ($svgdata = fread($fh, 1024 * 1024)) {
+		  if (!xml_parse($this->parser, $svgdata, feof($fh))) {
+		    $error_message = sprintf('SVG Error: %s at line %d', xml_error_string(xml_get_error_code($this->parser)), xml_get_current_line_number($this->parser));
+		    $this->Error($error_message);
+		  }
 		}
+		fclose($fh);
 		// free this XML parser
 		xml_parser_free($this->parser);
 		// restore previous graphic state

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -11346,7 +11346,7 @@ class TCPDF {
 					if ($i) {
 						$dash_string .= ' ';
 					}
-					$dash_string .= sprintf('%F', $v);
+					$dash_string .= sprintf('%F', ($v / $this->k));
 				}
 			}
 			if (!isset($style['phase']) OR !$style['dash']) {

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23792,11 +23792,11 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 			}
 			case 'svg': {
 				// start of SVG object
+				array_push($this->svgstyles, $svgstyle);
 				if(++$this->svg_tag_depth <= 1) {
 					break;
 				}
 				// inner SVG
-				array_push($this->svgstyles, $svgstyle);
 				$this->StartTransform();
 				$svgX = (isset($attribs['x'])?$attribs['x']:0);
 				$svgY = (isset($attribs['y'])?$attribs['y']:0);

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23193,7 +23193,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 				'color' => TCPDF_COLORS::convertHTMLColorToDec($svgstyle['stroke'], $this->spot_colors),
 				'width' => $this->getHTMLUnitToUnits($svgstyle['stroke-width'], 0, $this->svgunit, false),
 				'cap' => $svgstyle['stroke-linecap'],
-				'join' => $svgstyle['stroke-linejoin']
+				'join' => $svgstyle['stroke-linejoin'],
+				'dash' => 0
 				);
 			if (isset($svgstyle['stroke-dasharray']) AND !empty($svgstyle['stroke-dasharray']) AND ($svgstyle['stroke-dasharray'] != 'none')) {
 				$stroke_style['dash'] = $svgstyle['stroke-dasharray'];

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23760,6 +23760,13 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 				}
 			}
 		}
+		// Override previous svgstyles with latest value where available on the current element
+		// TODO: check all style attributes, not just inheritable ones
+		foreach (TCPDF_IMAGES::$svginheritprop as $attrib) {
+		  if (isset($attribs[$attrib])) {
+		    $svgstyle[$attrib] = $attribs[$attrib];
+		  }
+		}
 		// transformation matrix
 		if (!empty($ctm)) {
 			$tm = $ctm;


### PR DESCRIPTION
We have run into a number of issues with the SVG rendering of maps from Geoserver, mostly to do with line styles missing (due to not pulling in the default style), dash arrays being used where they shouldn't, and difficulty processing larger SVG files on some platforms.

This group of commits should fix the issues we have come across @findmaps.

I realise you're in the process of refactoring the whole library, but hopefully these fixes can be taken into consideration as part of that process.