### PR TITLE
BUGFIX: Removing invalid return path of fileGetContents

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1841,8 +1841,8 @@ class TCPDF_STATIC {
 	/**
 	 * Wrapper to use fopen only with local files
 	 * @param filename (string) Name of the file to open
-	 * @param $mode (string) 
-	 * @return Returns a file pointer resource on success, or FALSE on error.  
+	 * @param $mode (string)
+	 * @return Returns a file pointer resource on success, or FALSE on error.
 	 * @public static
 	 */
 	public static function fopenLocal($filename, $mode) {
@@ -1858,7 +1858,7 @@ class TCPDF_STATIC {
 	 * Reads entire file into a string.
 	 * The file can be also an URL.
 	 * @param $file (string) Name of the file or URL to read.
-	 * @return The function returns the read data or FALSE on failure. 
+	 * @return The function returns the read data or FALSE on failure.
 	 * @author Nicola Asuni
 	 * @since 6.0.025
 	 * @public static
@@ -1904,15 +1904,7 @@ class TCPDF_STATIC {
 				}
 			}
 		}
-		//
-		if (isset($_SERVER['SCRIPT_URI'])
-		    && !preg_match('%^(https?|ftp)://%', $file)
-		    && !preg_match('%^//%', $file)
-		) {
-		    $urldata = @parse_url($_SERVER['SCRIPT_URI']);
-		    return $urldata['scheme'].'://'.$urldata['host'].(($file[0] == '/') ? '' : '/').$file;
-		}
-		//
+		
 		$alt = array_unique($alt);
 		//var_dump($alt);exit;//DEBUG
 		foreach ($alt as $path) {
@@ -1949,7 +1941,7 @@ class TCPDF_STATIC {
 		return false;
 	}
 
-    
+
 
 	/**
 	 * Get ULONG from string (Big Endian 32-bit unsigned integer).
@@ -2088,7 +2080,7 @@ class TCPDF_STATIC {
 		return $a['i'];
 	}
 
-	
+
 	/**
 	 * Array of page formats
 	 * measures are calculated in this way: (inches * 72) or (millimeters * 72 / 25.4)


### PR DESCRIPTION
If the server tcpdf runs on has the environment variable REQUEST_URI set, the function fileGetContents replied with an URL and not the file content as expected.
This fix removes this invalid return.
