### PR TITLE
Barcode - Fixes for PHP7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "tecnickcom/tcpdf",
+	"name": "spoonity/tcpdf",
 	"version": "6.2.12",
 	"homepage": "http://www.tcpdf.org/",
 	"type": "library",

--- a/include/barcodes/pdf417.php
+++ b/include/barcodes/pdf417.php
@@ -588,7 +588,7 @@ class PDF417 {
 		// set error correction level
 		$ecl = $this->getErrorCorrectionLevel($ecl, $numcw);
 		// number of codewords for error correction
-		$errsize = (2 << $ecl);
+		$errsize = $ecl < 0 ? 0 : 2 << $ecl;
 		// calculate number of columns (number of codewords per row) and rows
 		$nce = ($numcw + $errsize + 1);
 		$cols = round((sqrt(4761 + (68 * $aspectratio * ROWHEIGHT * $nce)) - 69) / 34);
@@ -744,7 +744,7 @@ class PDF417 {
 		$maxecl = 8; // starting error level
 		$maxerrsize = (928 - $numcw); // available codewords for error
 		while ($maxecl > 0) {
-			$errsize = (2 << $ecl);
+			$errsize = $ecl < 0 ? 0 : 2 << $ecl;
 			if ($maxerrsize >= $errsize) {
 				break;
 			}
@@ -781,7 +781,7 @@ class PDF417 {
 		// get error correction coefficients
 		$ecc = $this->rsfactors[$ecl];
 		// number of error correction factors
-		$eclsize = (2 << $ecl);
+		$eclsize = $ecl < 0 ? 0 : 2 << $ecl;
 		// maximum index for $rsfactors[$ecl]
 		$eclmaxid = ($eclsize - 1);
 		// initialize array of error correction codewords

--- a/include/barcodes/qrcode.php
+++ b/include/barcodes/qrcode.php
@@ -1920,7 +1920,7 @@ class QRcode {
 				}
 			}
 			$l = $this->lengthIndicator($item['mode'], $version);
-			$m = 1 << $l;
+			$m = $l < 0 ? 0 : 1 << $l;
 			$num = (int)(($item['size'] + $m - 1) / $m);
 			$bits += $num * (4 + $l);
 		}
@@ -2138,7 +2138,7 @@ class QRcode {
 	 */
 	 protected function newFromNum($bits, $num) {
 		$bstream = $this->allocate($bits);
-		$mask = 1 << ($bits - 1);
+	    $mask = ($bits - 1) < 0 ? 0 : 1 << ($bits - 1);
 		for ($i=0; $i<$bits; ++$i) {
 			if ($num & $mask) {
 				$bstream[$i] = 1;
@@ -2368,7 +2368,7 @@ class QRcode {
 			$l = 2;
 		}
 		$bits = $this->lengthTableBits[$mode][$l];
-		$words = (1 << $bits) - 1;
+		$words = $bits < 0 ? -1 : (1 << $bits) - 1;
 		if ($mode == QR_MODE_KJ) {
 			$words *= 2; // the number of bytes is required
 		}
@@ -2744,25 +2744,26 @@ class QRcode {
 	protected function init_rs_char($symsize, $gfpoly, $fcr, $prim, $nroots, $pad) {
 		// Based on Reed solomon encoder by Phil Karn, KA9Q (GNU-LGPLv2)
 		$rs = null;
+		$shiftedSymsize = $symsize < 0 ? 0 : 1 << $symsize;
 		// Check parameter ranges
 		if (($symsize < 0) OR ($symsize > 8)) {
 			return $rs;
 		}
-		if (($fcr < 0) OR ($fcr >= (1<<$symsize))) {
+		if (($fcr < 0) OR ($fcr >= ($shiftedSymsize))) {
 			return $rs;
 		}
-		if (($prim <= 0) OR ($prim >= (1<<$symsize))) {
+		if (($prim <= 0) OR ($prim >= ($shiftedSymsize))) {
 			return $rs;
 		}
-		if (($nroots < 0) OR ($nroots >= (1<<$symsize))) {
+		if (($nroots < 0) OR ($nroots >= ($shiftedSymsize))) {
 			return $rs;
 		}
-		if (($pad < 0) OR ($pad >= ((1<<$symsize) -1 - $nroots))) {
+		if (($pad < 0) OR ($pad >= (($shiftedSymsize) -1 - $nroots))) {
 			return $rs;
 		}
 		$rs = array();
 		$rs['mm'] = $symsize;
-		$rs['nn'] = (1 << $symsize) - 1;
+		$rs['nn'] = ($shiftedSymsize) - 1;
 		$rs['pad'] = $pad;
 		$rs['alpha_to'] = array_fill(0, ($rs['nn'] + 1), 0);
 		$rs['index_of'] = array_fill(0, ($rs['nn'] + 1), 0);
@@ -2777,7 +2778,7 @@ class QRcode {
 			$rs['index_of'][$sr] = $i;
 			$rs['alpha_to'][$i] = $sr;
 			$sr <<= 1;
-			if ($sr & (1 << $symsize)) {
+			if ($sr & ($shiftedSymsize)) {
 				$sr ^= $gfpoly;
 			}
 			$sr &= $rs['nn'];

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -8607,7 +8607,7 @@ class TCPDF {
 									// array of bit settings
 									$flag = 0;
 									foreach($pl['opt']['ff'] as $val) {
-										$flag += 1 << ($val - 1);
+										$flag += ($val - 1) < 0 ? 0 : 1 << ($val - 1);
 									}
 								} else {
 									$flag = intval($pl['opt']['ff']);


### PR DESCRIPTION
http://php.net/manual/en/migration70.incompatible.php

Negative Bitshifts are throwing a ArithmeticError now. 

2 Choices: Prevent negative Bitshifts (like here) or catch the Exception. 