### PR TITLE
Barcode - Fixes for PHP7

### DIFF
--- a/include/barcodes/pdf417.php
+++ b/include/barcodes/pdf417.php
@@ -588,7 +588,12 @@ class PDF417 {
 		// set error correction level
 		$ecl = $this->getErrorCorrectionLevel($ecl, $numcw);
 		// number of codewords for error correction
-		$errsize = (2 << $ecl);
+		try{
+			$errsize = (2 << $ecl);
+		}catch( ArithmeticError $e){
+			$errsize = 0;
+		}
+
 		// calculate number of columns (number of codewords per row) and rows
 		$nce = ($numcw + $errsize + 1);
 		$cols = round((sqrt(4761 + (68 * $aspectratio * ROWHEIGHT * $nce)) - 69) / 34);
@@ -744,7 +749,12 @@ class PDF417 {
 		$maxecl = 8; // starting error level
 		$maxerrsize = (928 - $numcw); // available codewords for error
 		while ($maxecl > 0) {
-			$errsize = (2 << $ecl);
+			try{
+				$errsize = (2 << $ecl);
+			}catch( ArithmeticError $e){
+				$errsize = 0;
+			}
+			
 			if ($maxerrsize >= $errsize) {
 				break;
 			}
@@ -781,7 +791,12 @@ class PDF417 {
 		// get error correction coefficients
 		$ecc = $this->rsfactors[$ecl];
 		// number of error correction factors
-		$eclsize = (2 << $ecl);
+		try{
+			$eclsize = (2 << $ecl);
+		}catch( ArithmeticError $e){
+			$eclsize = 0;
+		}
+
 		// maximum index for $rsfactors[$ecl]
 		$eclmaxid = ($eclsize - 1);
 		// initialize array of error correction codewords


### PR DESCRIPTION
http://php.net/manual/en/migration70.incompatible.php

Negative Bitshifts are throwing a ArithmeticError now.

2 Choices: Prevent negative Bitshifts or catch the Exception  (like here).
