### PR TITLE
fixed multicell border

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -5944,7 +5944,9 @@ class TCPDF {
 			if ($startpage == $endpage) {
 				// single page
 				for ($column = $startcolumn; $column <= $endcolumn; ++$column) { // for each column
-					$this->selectColumn($column);
+					if ($column != $this->current_column) {
+						$this->selectColumn($column);
+					}
 					if ($this->rtl) {
 						$this->x -= $mc_margin['R'];
 					} else {
@@ -5973,7 +5975,9 @@ class TCPDF {
 				} // end for each column
 			} elseif ($page == $startpage) { // first page
 				for ($column = $startcolumn; $column < $this->num_columns; ++$column) { // for each column
-					$this->selectColumn($column);
+					if ($column != $this->current_column) {
+						$this->selectColumn($column);
+					}
 					if ($this->rtl) {
 						$this->x -= $mc_margin['R'];
 					} else {
@@ -5992,7 +5996,9 @@ class TCPDF {
 				} // end for each column
 			} elseif ($page == $endpage) { // last page
 				for ($column = 0; $column <= $endcolumn; ++$column) { // for each column
-					$this->selectColumn($column);
+					if ($column != $this->current_column) {
+						$this->selectColumn($column);
+					}
 					if ($this->rtl) {
 						$this->x -= $mc_margin['R'];
 					} else {
@@ -6015,7 +6021,9 @@ class TCPDF {
 				} // end for each column
 			} else { // middle page
 				for ($column = 0; $column < $this->num_columns; ++$column) { // for each column
-					$this->selectColumn($column);
+					if ($column != $this->current_column) {
+						$this->selectColumn($column);
+					}
 					if ($this->rtl) {
 						$this->x -= $mc_margin['R'];
 					} else {


### PR DESCRIPTION
A bug occurs when trying to print a table inside a page that itself contains columns. The table cell borders are all printed starting from the leftmost horizontal position within the page column.

More specifically, this occurs when using MultiCell to print each table cell's text. Say that the page has  2 equal columns of width 80, and that we want to print text in a table with 4 columns of width 20 each (the widths of the table columns does not matter). The text of each table cell is printed using MultiCell. Each cell has a non-null border (say `B`). When the table gets printed, we'd expect the border of each cell to be printed from x position 0 to 20, 20 to 40, 40 to 60, 60 to 80 (these numbers refer to the horizontal positions relative to the left edge of the current page column). However, the borders get printed at x position 0 to 20 for each table cell, so cells in table columns 2 to 4 look like they have no border.

The offending code lies in MultiCell's calls to `selectColumn` when printing borders. `selectColumn` recomputes the horizontal position and sets it to be the leftmost horizontal position within the specified column. This is the normal intended behavior for `selectColumn`; the problem is that the method should only be invoked when the printing actually switches to a new column. As long as the printing remains within the same column, the method does not need to, and should not, be invoked. 

In the example above, this is exactly the case in point: as we print each table cell in a given row, there is no reason to switch to another page column. The logic to switch to another column would only matter after printing a complete row, but not within a row.

This MR fixes that.

```<?php

require_once('tcpdf_include.php');

// create new PDF document
$pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);

$pdf->setPrintHeader(false);
$pdf->setPrintFooter(false);

// add a page
$pdf->AddPage();

// set columns
$pdf->setEqualColumns(2, 80);

// set text for table cells
$data = array(
    'Lorem ipsum dolor sit amet',
    'consectetur adipisicing elit',
    'sed do eiusmod tempor incididunt',
    'ut labore et dolore magna aliqua.',
);

// define border
$border = 'B';

// define alignment
$align = 'L';

foreach ($data as $cell) {
    $pdf->MultiCell(20, 0, $cell, $border, $align, 0, 0);
}

$pdf->Output('columns.pdf', 'I');
```