### PR TITLE
Remove fonts from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 	},
 	"autoload": {
 		"classmap": [
-		"fonts",
 		"config",
 		"include",
 		"tcpdf.php",


### PR DESCRIPTION
It seems `fonts/` shouldn't be autoloaded since there is no class or interface definition there. Removing it can help composer take less time to generate classmap. Besides that, a personal reason is I'm sort of implementing my own autoloading mechanism with parsing and these fonts files take really long time to parse. 

Thanks