### PR TITLE
Fix for Notice -> Undefined index: F0

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -21511,7 +21511,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 			} else {
 				// placemark to be replaced with the correct number
 				$pagenum = '{#'.($outline['p']).'}';
-				if ($templates['F'.$outline['l']]) {
+				if (isset($templates['F'.$outline['l']]) && $templates['F'.$outline['l']]) {
 					$pagenum = '{'.$pagenum.'}';
 				}
 				$maxpage = max($maxpage, $outline['p']);


### PR DESCRIPTION
Notice happens when using a numberless TOC and breaks local testing.