### PR TITLE
support UTF-8 unicode alpanumeric characters in pdf filename

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7563,8 +7563,8 @@ class TCPDF {
 		}
 		$dest = strtoupper($dest);
 		if ($dest[0] != 'F') {
-			$name = preg_replace('/[\s]+/', '_', $name);
-			$name = preg_replace('/[^a-zA-Z0-9_\.-]/', '', $name);
+			$name = preg_replace ( '/[^[:alnum:][:space:]\_\.\-]/u', '', $name );
+			$name = preg_replace ( '/[[:space:]]/u', '_', $name );
 		}
 		if ($this->sign) {
 			// *** apply digital signature to the document ***


### PR DESCRIPTION
for example, Æ Ø Å (frequently used in Norway)

- but not just Norwegians will benefit, this may benefit Chinese, Japanese, Swedish, Danish, Vietnamese, Brazilians, Russians, Koreans (mostly South-Koreans), Turkish, Polish, Arabic, French, and many others