### PR TITLE
fix Undesired mouseover effect on links in PDF on Chrome Pdf Viewer

### DIFF
--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -1,3 +1,6 @@
+Unreleased
+	- fix Undesired mouseover effect on links in PDF on Chrome Pdf Viewer
+
 6.2.13 (2016-06-10)
 	- IMPORTANT: A new version of this library is under development at https://github.com/tecnickcom/tc-lib-pdf and as a consequence this version will not receive any additional development or support. This version should be considered obsolete, new projects should use the new version as soon it will become stable.
 

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -8157,7 +8157,9 @@ class TCPDF {
 						$annots .= ' /FT /'.$pl['opt']['ft'];
 						$formfield = true;
 					}
-					$annots .= ' /Contents '.$this->_textstring($pl['txt'], $annot_obj_id);
+					if ($pl['opt']['subtype'] !== 'Link') {
+						$annots .= ' /Contents '.$this->_textstring($pl['txt'], $annot_obj_id);
+					}
 					$annots .= ' /P '.$this->page_obj_id[$n].' 0 R';
 					$annots .= ' /NM '.$this->_datastring(sprintf('%04u-%04u', $n, $key), $annot_obj_id);
 					$annots .= ' /M '.$this->_datestring($annot_obj_id, $this->doc_modification_timestamp);


### PR DESCRIPTION
It is to fix a pb on Chrome Pdf Viewer.

Lots of pdf lib have the pb : mpdf/mpdf#283

I know that now this package is deprecated, but since the new lib is not ready, it could be cool to manage bug fix on this version ;)