### PR TITLE
Add url as an alternative path instead of returning directly

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1910,7 +1910,7 @@ class TCPDF_STATIC {
 		    && !preg_match('%^//%', $file)
 		) {
 		    $urldata = @parse_url($_SERVER['SCRIPT_URI']);
-		    return $urldata['scheme'].'://'.$urldata['host'].(($file[0] == '/') ? '' : '/').$file;
+		    $alt[] = $urldata['scheme'].'://'.$urldata['host'].(($file[0] == '/') ? '' : '/').$file;
 		}
 		//
 		$alt = array_unique($alt);


### PR DESCRIPTION
When `TCPDF_STATIC::fileGetContents` is called with a relative path while `$_SERVER['SCRIPT_URI']` is set, this method _always_ used the web-url to retrieve the contents. This fix will just add the url as one of the alternatives to be checked later in the method.