### PR TITLE
Support ctg files that have not been lowercased

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1541,16 +1541,28 @@ class TCPDF_FONTS {
 	 * @public static
 	 */
 	public static function getFontFullPath($file, $fontdir=false) {
-		$fontfile = '';
-		// search files on various directories
-		if (($fontdir !== false) AND @file_exists($fontdir.$file)) {
-			$fontfile = $fontdir.$file;
-		} elseif (@file_exists(self::_getfontpath().$file)) {
-			$fontfile = self::_getfontpath().$file;
-		} elseif (@file_exists($file)) {
-			$fontfile = $file;
+		// Look for both the original file name and the lowercased variant
+		$alternatives = [
+			$file,
+			strtolower($file)
+		];
+
+		foreach ($alternatives as $alternative) {
+			// search files on various directories
+			if (($fontdir !== false) AND @file_exists($fontdir.$alternative)) {
+				return $fontdir.$alternative;
+			}
+
+			if (@file_exists(self::_getfontpath().$alternative)) {
+				return self::_getfontpath() . $alternative;
+			}
+
+			if (@file_exists($alternative)) {
+				return $alternative;
+			}
 		}
-		return $fontfile;
+
+		return '';
 	}
 
 

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -8994,7 +8994,7 @@ class TCPDF {
 			// Embed CIDToGIDMap
 			// A specification of the mapping from CIDs to glyph indices
 			// search and get CTG font file to embedd
-			$ctgfile = strtolower($font['ctg']);
+			$ctgfile = $font['ctg'];
 			// search and get ctg font file to embedd
 			$fontfile = TCPDF_FONTS::getFontFullPath($ctgfile, $fontdir);
 			if (TCPDF_STATIC::empty_string($fontfile)) {


### PR DESCRIPTION
In our (and probably) other legacy codebase previously created fonts using ufm have not all been lowercased. This pull request will support both the lowercased files and the case sensitive files.