### PR TITLE
Reverse order of operations in getErrorCorrectionLevel

### DIFF
--- a/include/barcodes/pdf417.php
+++ b/include/barcodes/pdf417.php
@@ -740,16 +740,6 @@ class PDF417 {
 	 * @protected
 	 */
 	protected function getErrorCorrectionLevel($ecl, $numcw) {
-		// get maximum correction level
-		$maxecl = 8; // starting error level
-		$maxerrsize = (928 - $numcw); // available codewords for error
-		while ($maxecl > 0) {
-			$errsize = (2 << $ecl);
-			if ($maxerrsize >= $errsize) {
-				break;
-			}
-			--$maxecl;
-		}
 		// check for automatic levels
 		if (($ecl < 0) OR ($ecl > 8)) {
 			if ($numcw < 41) {
@@ -763,6 +753,16 @@ class PDF417 {
 			} else {
 				$ecl = $maxecl;
 			}
+		}
+		// get maximum correction level
+		$maxecl = 8; // starting error level
+		$maxerrsize = (928 - $numcw); // available codewords for error
+		while ($maxecl > 0) {
+			$errsize = (2 << $ecl);
+			if ($maxerrsize >= $errsize) {
+				break;
+			}
+			--$maxecl;
 		}
 		if ($ecl > $maxecl) {
 			$ecl = $maxecl;


### PR DESCRIPTION
getErrorCorrectionLevel throws a fatal ArithmeticError when a negative number is passed for the `$ecl` parameter. By reversing the order of operations in this function, this error can be easily avoided.

Here is the error log showing the specifics of the error:
```
[24-Jun-2017 23:54:12 Europe/Berlin] PHP Fatal error:  Uncaught ArithmeticError: Bit shift by negative number in /Applications/MAMP/htdocs/TCPDF/include/barcodes/pdf417.php:747
Stack trace:
#0 /Applications/MAMP/htdocs/TCPDF/include/barcodes/pdf417.php(589): PDF417->getErrorCorrectionLevel(-1, 14)
#1 /Applications/MAMP/htdocs/TCPDF/tcpdf_barcodes_2d.php(289): PDF417->__construct('http://www.tcpd...', -1, 2, Array)
#2 /Applications/MAMP/htdocs/TCPDF/tcpdf_barcodes_2d.php(69): TCPDF2DBarcode->setBarcode('http://www.tcpd...', 'PDF417')
#3 /Applications/MAMP/htdocs/TCPDF/examples/barcodes/example_2d_pdf417_png.php(46): TCPDF2DBarcode->__construct('http://www.tcpd...', 'PDF417')
#4 {main}
  thrown in /Applications/MAMP/htdocs/TCPDF/include/barcodes/pdf417.php on line 747
```