### PR TITLE
refactoring write2DBarcode() in tcpdf

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -15509,7 +15509,7 @@ class TCPDF {
 	 * @since 4.5.037 (2009-04-07)
 	 * @public
 	 */
-	public function write2DBarcode($code, $type, $x='', $y='', $w='', $h='', $style='', $align='', $distort=false) {
+	public function write2DBarcode($code, $type, $x='', $y='', $w='', $h='', $style=array(), $align='', $distort=false) {
 		if (TCPDF_STATIC::empty_string(trim($code))) {
 			return;
 		}


### PR DESCRIPTION
Function write2DBarcode() have problem in 7.1.6, with this fix run in PHP 5 Upwards.

source:
http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.types