### PR TITLE
"Non well formed numeric value" error occurs in PHP 7

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -4453,6 +4453,7 @@ class TCPDF {
 	 * @see SetFont()
 	 */
 	public function SetFontSize($size, $out=true) {
+		$size = (float)$size;
 		// font size in points
 		$this->FontSizePt = $size;
 		// font size in user units


### PR DESCRIPTION
The $size variable in the SetFontSize function is supposed to be a float type, but a string can be passed in like "14px" causing an error in PHP 7.  Re-casting the variable is a simple solution to fix the variable type if it was incorrectly passed in.