### PR TITLE
Remove useless and dangerous shutdown handler

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -1983,9 +1983,6 @@ class TCPDF {
 		$this->default_graphic_vars = $this->getGraphicVars();
 		$this->header_xobj_autoreset = false;
 		$this->custom_xmp = '';
-		// Call cleanup method after script execution finishes or exit() is called.
-		// NOTE: This will not be executed if the process is killed with a SIGTERM or SIGKILL signal.
-		register_shutdown_function(array($this, '_destroy'), true);
 	}
 
 	/**


### PR DESCRIPTION
As the shutdown handler contains a reference to the TCPDF instance itself, it prevents the destructor from being called.
In turn, the restoration of the `mb_internal_encoding` does not work correctly.

This affects all code that is executed after interaction with TCPDF. Code which uses multi-byte functions is using the wrong encoding (ASCII instead of the configured one). This might lead to wrong string operation results and as a consequence to data corruption.

I found the issue in an application which generates PDF reports. The mutation of global state (`mb_internal_encoding`) due to the bug led to test failures in another part of the application which is using multi-byte functions.

The destructor also calls the _destroy method, thus cleanup still works after removal of the shutdown handler.
A bonus of the removal is reduced memory usage, as the memory for the TCPDF instance is freed as soon as the object is not referenced anymore.
For an explicit cleanup (and in turn `mb_internal_encoding` restoration), developers may call `unset($pdf)` before other code execution.

Test script:
```php
<?php
error_reporting(E_ALL);
require_once('vendor/autoload.php');

// should usually be UTF-8 on somewhat recent PHP versions
var_dump(mb_internal_encoding());

$pdf = new TCPDF();
$pdf->SetFont('times', 'BI', 20);
$pdf->AddPage();

$txt = <<<EOD
TCPDF Example for mb_internal_encoding restoration bug.
EOD;

$pdf->Write(0, $txt, '', 0, 'C', true, 0, false, false, 0);
$pdf->Output('example.pdf', 'S');

// trigger the destructor, not necessary if the TCPDF instance
// is created e.g. as a scoped variable within a method.
unset($pdf);

// should be the same as the one before
var_dump(mb_internal_encoding());

// at the end, the destructor is triggered anyway
```

Expected output:
```
string(5) "UTF-8"
string(5) "UTF-8"
```

Actual output:
```
string(5) "UTF-8"
string(5) "ASCII"
```