### PR TITLE
Fix continue in switch for PHP7.3

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -17783,7 +17783,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 											// justify block
 											if (!TCPDF_STATIC::empty_string($this->lispacer)) {
 												$this->lispacer = '';
-												continue;
+												break;
 											}
 											preg_match('/([0-9\.\+\-]*)[\s]([0-9\.\+\-]*)[\s]([0-9\.\+\-]*)[\s]('.$strpiece[1][0].')[\s](re)([\s]*)/x', $pmid, $xmatches);
 											if (!isset($xmatches[1])) {


### PR DESCRIPTION
BC break: no

In PHP7.3 there is an error when continue is used in switch. I was thinking about `continue 2`, but it may change logic of this method. Break is more safe.

PHP change: https://github.com/php/php-src/commit/04e3523b7d095341f65ed5e71a3cac82fca690e4
RFC: https://wiki.php.net/rfc/continue_on_switch_deprecation

(RFC is Withdrawn from PHP7.3 - instead of it warning is thrown - see PHP change).