### PR TITLE
Add ignore Annotation annotation

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -130,6 +130,9 @@ require_once(dirname(__FILE__).'/include/tcpdf_static.php');
  * @brief PHP class for generating PDF documents without requiring external extensions.
  * @version 6.2.8
  * @author Nicola Asuni - info@tecnick.com
+ * @IgnoreAnnotation("protected")
+ * @IgnoreAnnotation("public")
+ * @IgnoreAnnotation("pre")
  */
 class TCPDF {
 


### PR DESCRIPTION
Add IgnoreAnnotation annotations to ignore `@public`, `@protected`, `@pre` cause doctrine parser searching for imports and is throwing

`[Semantical Error] The annotation "@pre" in method TCPDF::getStringHeight() was never imported. Did you maybe forget to add a "use" statement for this annotation?
`