### PR TITLE
Fix of issue with html tags inside RTL languages

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -18318,7 +18318,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 				}
 				// text
 				$this->htmlvspace = 0;
-				if ((!$this->premode) AND $this->isRTLTextDir()) {
+				$isRTLString = preg_match(TCPDF_FONT_DATA::$uni_RE_PATTERN_RTL, $dom[$key]['value']) || preg_match(TCPDF_FONT_DATA::$uni_RE_PATTERN_ARABIC, $dom[$key]['value']);
+				if ((!$this->premode) AND $this->isRTLTextDir() AND !$isRTLString) {
 					// reverse spaces order
 					$lsp = ''; // left spaces
 					$rsp = ''; // right spaces
@@ -18333,7 +18334,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 				if ($newline) {
 					if (!$this->premode) {
 						$prelen = strlen($dom[$key]['value']);
-						if ($this->isRTLTextDir()) {
+						if ($this->isRTLTextDir() AND !$isRTLString) {
 							// right trim except non-breaking space
 							$dom[$key]['value'] = $this->stringRightTrim($dom[$key]['value']);
 						} else {


### PR DESCRIPTION
Fix of issue with html tags inside RTL languages, space reversion shouldn't be performed on RTL strings. Consider next code:

$pdf->SetFont('dejavusans', '', 14, '', false);
$pdf->setRTL(true);
$htmlhebrew = "אנ <b>לא</b> ודעת";
$pdf->WriteHTML($htmlhebrew, true, 0, true, 0);

it will output
אנלאודעת

with missing spaces around bold text לא

Expected output is:

אנ לא ודעת

with spaces around bold text לא