### PR TITLE
Security fix for disclosed stream wrapper attack

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6840,6 +6840,11 @@ class TCPDF {
 			// image from string
 			$imgdata = substr($file, 1);
 		} else { // image file
+			if ($file[0] === '*') {
+				// image as external stream
+				$file = substr($file, 1);
+				$exurl = $file;
+			}
 			$wrappers = stream_get_wrappers();
 			foreach ($wrappers as $wrapper) {
 				if ($wrapper === 'http' || $wrapper === 'https') {
@@ -6848,11 +6853,6 @@ class TCPDF {
 				if (stripos($file, $wrapper.'://') === 0) {
 					$this->Error('Stream wrappers in file paths are not supported');
 				}
-			}
-			if ($file[0] === '*') {
-				// image as external stream
-				$file = substr($file, 1);
-				$exurl = $file;
 			}
 			// check if is a local file
 			if (!@file_exists($file)) {

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6840,6 +6840,15 @@ class TCPDF {
 			// image from string
 			$imgdata = substr($file, 1);
 		} else { // image file
+			$wrappers = stream_get_wrappers();
+			foreach ($wrappers as $wrapper) {
+				if ($wrapper === 'http' || $wrapper === 'https') {
+					continue;
+				}
+				if (strpos($file, $wrapper.'://') === 0) {
+					$this->Error('Stream wrappers in file paths are not supported');
+				}
+			}
 			if ($file[0] === '*') {
 				// image as external stream
 				$file = substr($file, 1);

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6845,7 +6845,7 @@ class TCPDF {
 				if ($wrapper === 'http' || $wrapper === 'https') {
 					continue;
 				}
-				if (strpos($file, $wrapper.'://') === 0) {
+				if (stripos($file, $wrapper.'://') === 0) {
 					$this->Error('Stream wrappers in file paths are not supported');
 				}
 			}


### PR DESCRIPTION
This PR fixes a security vulnerability that has been presented at this years Black Hat USA 2018 conference. The white paper is available here:

https://github.com/s-n-t/presentations/blob/master/us-18-Thomas-It's-A-PHP-Unserialization-Vulnerability-Jim-But-Not-As-We-Know-It-wp.pdf

The fix checks if the file path begins with a stream wrapper other than `http` and `https` and throws an exception if so.