### PR TITLE
Fixes MultiCell not working with negative y values

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -5769,10 +5769,9 @@ class TCPDF {
 			$this->resetLastH();
 		}
 		if (!TCPDF_STATIC::empty_string($y)) {
-			$this->SetY($y);
-		} else {
-			$y = $this->GetY();
+			$this->SetY($y); // set y in order to convert negative y values to positive ones
 		}
+		$y = $this->GetY();
 		$resth = 0;
 		if (($h > 0) AND $this->inPageBody() AND (($y + $h + $mc_margin['T'] + $mc_margin['B']) > $this->PageBreakTrigger)) {
 			// spit cell in more pages/columns


### PR DESCRIPTION
The current implementation does not allow negative y values for the `MultiCell` method.

If you enter a negative y value, then the method `$this->SetY($y)` is called. It converts the negative y position to a positive position and sets `$this->y` correctly.
The method `MultiCell` however still uses the local `$y` which is still negative and this leads to errors.