### PR TITLE
Fix unsupported operand types error when codepoints arrays are merged

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -2003,7 +2003,10 @@ class TCPDF_FONTS {
 			$chars = str_split($str);
 			$carr = array_map('ord', $chars);
 		}
-		$currentfont['subsetchars'] += array_fill_keys($carr, true);
+		if (is_array($currentfont['subsetchars']) && is_array($carr))
+			$currentfont['subsetchars'] += array_fill_keys($carr, true);
+		else
+			array_merge($currentfont['subsetchars'], $carr);
 		return $carr;
 	}
 

--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -2006,7 +2006,7 @@ class TCPDF_FONTS {
 		if (is_array($currentfont['subsetchars']) && is_array($carr))
 			$currentfont['subsetchars'] += array_fill_keys($carr, true);
 		else
-			array_merge($currentfont['subsetchars'], $carr);
+			$currentfont['subsetchars'] = array_merge($currentfont['subsetchars'], $carr);
 		return $carr;
 	}
 


### PR DESCRIPTION
I had some cases where $currentfont['subsetchars'] was 0, which lead to fatal errors because of unsupported operand types. This is fixed by this change. 