### PR TITLE
Fixing error on maxchwidth

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6306,7 +6306,9 @@ class TCPDF {
 		// calculate maximum width for a single character on string
 		$chrw = $this->GetArrStringWidth($chars, '', '', 0, true);
 		array_walk($chrw, array($this, 'getRawCharWidth'));
-		$maxchwidth = max($chrw);
+		if (0 < count($chrw)) {
+			$maxchwidth = max($chrw);
+		}
 		// get array of chars
 		$uchars = TCPDF_FONTS::UTF8ArrayToUniArray($chars, $this->isunicode);
 		// get the number of characters


### PR DESCRIPTION
We got the error:
> Warning: max(): Array must contain at least one element

See https://github.com/wallabag/wallabag/issues/2776 & https://github.com/j0k3r/graby/pull/169

![image](https://user-images.githubusercontent.com/62333/47600988-27411d00-d9ca-11e8-9440-78913c3cf4a4.png)

By that time we thought the project was dead so we don't provide a PR to fix that problem.
Instead we forked your repo and fixed the issue on our side https://github.com/wallabag/tcpdf
Instead of maintaining the fork, we think it's better to keep fixes in one place: your repo.

I recently rebased our repo with latest changes from your repo and it seems only that issue exists: https://github.com/tecnickcom/TCPDF/compare/master...wallabag:master