### PR TITLE
[BUGFIX] fix SpotColor handling in HTML

### DIFF
--- a/include/tcpdf_colors.php
+++ b/include/tcpdf_colors.php
@@ -358,7 +358,7 @@ class TCPDF_COLORS {
 				$color_code = self::$webcolor[$color];
 			} else {
 				// spot color
-				$returncolor = self::getSpotColor($color, $spotc);
+				$returncolor = self::getSpotColor($hcolor, $spotc);
 				if ($returncolor === false) {
 					$returncolor = $defcol;
 				}


### PR DESCRIPTION
As the spot color array contains the user defined spotcolors provided by AddColor() we need to use the original color name here (as stored in $hcolor) and not the flattened one.

Example for usage <span style="color:SPOTCOLOR 15/5;">Your text here</span>