### PR TITLE
Update custom_xmp line to comply with the RFC standard for XMP

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -9627,8 +9627,8 @@ class TCPDF {
 		$xmp .= "\t\t\t\t".'</rdf:Bag>'."\n";
 		$xmp .= "\t\t\t".'</pdfaExtension:schemas>'."\n";
 		$xmp .= "\t\t".'</rdf:Description>'."\n";
-		$xmp .= "\t".'</rdf:RDF>'."\n";
 		$xmp .= $this->custom_xmp;
+		$xmp .= "\t".'</rdf:RDF>'."\n";		
 		$xmp .= '</x:xmpmeta>'."\n";
 		$xmp .= '<?xpacket end="w"?>';
 		$out = '<< /Type /Metadata /Subtype /XML /Length '.strlen($xmp).' >> stream'."\n".$xmp."\n".'endstream'."\n".'endobj';


### PR DESCRIPTION
I believe the line where custom XMP is embedded into the rest of the XMP metadata is not correct.  

In the original any metadata embedded resulted in a non-standard XMP that didn't show up in e.g. Adobe Acrobat.