### PR TITLE
unlink every image cached on disk (fixes cache leak of string images)

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -9994,6 +9994,9 @@ class TCPDF {
 		$this->_out($o);
 		$this->_out('%%EOF');
 		$this->state = 3; // end-of-doc
+		foreach($this->imagekeys as $file) {
+			unlink($file);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Under certain conditions the cache files created for string images are never deleted from disk. 

Cases I observed on Arch linux using the latest revision, PHP 7.2.8, example_009.php :

1. set insufficient permissions on K_PATH_CACHE directory
2. tcpdf will fall back on system wide 777 tmp directory for caching
3. cache file remains in place after the script ends 

Case 2:

1. K_PATH_CACHE lacks the trailing slash (for example: '/tmp')
2. directory has sufficient permissions (rw and execute)
3. no fallback, same result (cache files start piling up)

The problem seems to stem from bad sanitization of K_PATH_CACHE coupled to a lack of explicit unlink() calls (which were present in earlier versions of tcpdf.php that don't suffer from this behaviour). 

Other related reports exist, see for example: 
https://www.drupal.org/project/tcpdf/issues/2700117 