### PR TITLE
Fix TCPDF_STATIC::fileGetContents()

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1926,7 +1926,7 @@ class TCPDF_STATIC {
 		$alt = array_unique($alt);
 		foreach ($alt as $path) {
 			if (!self::file_exists($path)) {
-				return false;
+				continue;
 			}
 			$ret = @file_get_contents($path);
 			if ($ret !== false) {


### PR DESCRIPTION
Currently only the first path in the `$alt` array gets checked. This pull request fixes this so that all paths are checked.