### PR TITLE
Change/fix named destination implementation

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -8368,7 +8368,7 @@ class TCPDF {
 							if (is_string($pl['txt']) && !empty($pl['txt'])) {
 								if ($pl['txt'][0] == '#') {
 									// internal destination
-									$annots .= ' /Dest /'.TCPDF_STATIC::encodeNameObject(substr($pl['txt'], 1));
+									$annots .= ' /A <</S /GoTo /D '.$this->_datastring($this->unhtmlentities(substr($pl['txt'], 1))).'>>';
 								} elseif ($pl['txt'][0] == '%') {
 									// embedded PDF file
 									$filename = basename(substr($pl['txt'], 1));


### PR DESCRIPTION
We noticed that named destination links created by TCPDF worked when the resulting PDFs were viewed in Google Chrome's built-in PDF viewer but not in Acrobat.  (In Acrobat, clicking on the link did nothing.  If I right-click on a link and choose Edit, Acrobat says that the action is to "Go to a page in this document," but it doesn't give any details or let me edit it - as if it doesn't know how to interpret the link's contents.)

From comparison with links created by Acrobat itself, and from comparison with unofficial named destination support for FPDF (http://www.fpdf.org/en/script/script99.php), this update seems to fix the problem.

I've tested this update in both Google Chrome and Acrobat, and it appears to work. However, I'm not very familiar with PDF internals, so I'd appreciate a review.