### PR TITLE
Fix support for image URLs via zip wrapper

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1808,8 +1808,8 @@ class TCPDF_STATIC {
 	/**
 	 * Wrapper to use fopen only with local files
 	 * @param filename (string) Name of the file to open
-	 * @param $mode (string) 
-	 * @return Returns a file pointer resource on success, or FALSE on error.  
+	 * @param $mode (string)
+	 * @return Returns a file pointer resource on success, or FALSE on error.
 	 * @public static
 	 */
 	public static function fopenLocal($filename, $mode) {
@@ -1850,15 +1850,29 @@ class TCPDF_STATIC {
 	 * Wrapper for file_exists.
 	 * Checks whether a file or directory exists.
 	 * Only allows some protocols and local files.
-	 * @param filename (string) Path to the file or directory. 
-	 * @return Returns TRUE if the file or directory specified by filename exists; FALSE otherwise.  
+	 * @param filename (string) Path to the file or directory.
+	 * @return Returns TRUE if the file or directory specified by filename exists; FALSE otherwise.
 	 * @public static
 	 */
 	public static function file_exists($filename) {
 		if (preg_match('|^https?://|', $filename) == 1) {
 			return self::url_exists($filename);
 		}
-		if (strpos($filename, '://')) {
+
+		if ((substr($filename, 0, 6) == "zip://") && in_array("zip", stream_get_wrappers())) {
+			// file_exists() doesn't support zip-wrapper
+			list($arch_path, $subfile_path) = explode("#", substr($filename, 6));
+			if (@file_exists($arch_path)) {
+				$zip = new ZipArchive;
+				$res = $zip->open($arch_path);
+				if (($res === true) && $zip->statName($subfile_path)) {
+					$zip->close();
+					return true;
+				}
+			}
+			return false;
+		}
+		else if (strpos($filename, '://')) {
 			return false; // only support http and https wrappers for security reasons
 		}
 		return @file_exists($filename);
@@ -1868,7 +1882,7 @@ class TCPDF_STATIC {
 	 * Reads entire file into a string.
 	 * The file can be also an URL.
 	 * @param $file (string) Name of the file or URL to read.
-	 * @return The function returns the read data or FALSE on failure. 
+	 * @return The function returns the read data or FALSE on failure.
 	 * @author Nicola Asuni
 	 * @since 6.0.025
 	 * @public static
@@ -2098,7 +2112,7 @@ class TCPDF_STATIC {
 		return $a['i'];
 	}
 
-	
+
 	/**
 	 * Array of page formats
 	 * measures are calculated in this way: (inches * 72) or (millimeters * 72 / 25.4)


### PR DESCRIPTION
After patch a5135e2cf02f8c935b71e9e7d676f0f1d31b1b9d you lost support images inside zip archives!

for example PHPSpreadsheet export to pdf can use html with image paths like: "zip://d:\\foo\\table.xlsx#xl/media/photo.png"

This patch fix this case.