### PR TITLE
URI in PDF can result in E_NOTICE

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -8380,7 +8380,7 @@ class TCPDF {
 									$annots .= ' /A << /S /JavaScript /JS '.$this->_textstring($jsa, $annot_obj_id).'>>';
 								} else {
 									$parsedUrl = parse_url($pl['txt']);
-									if (empty($parsedUrl['scheme']) AND (strtolower(substr($parsedUrl['path'], -4)) == '.pdf')) {
+									if (empty($parsedUrl['scheme']) AND (!empty($parsedUrl['path']) && strtolower(substr($parsedUrl['path'], -4)) == '.pdf')) {
 										// relative link to a PDF file
 										$dest = '[0 /Fit]'; // default page 0
 										if (!empty($parsedUrl['fragment'])) {


### PR DESCRIPTION
Generating a PDF file with a hyperlink like "tel:12345" results in an error: "Errstr: Undefined index: path" due to the fact that parse_url should only be used for URL not URI. 

SOURCE: https://www.php.net/manual/en/function.parse-url.php
"This function is intended specifically for the purpose of parsing URLs and not URIs."

This fix does not prevent parsing the link but checks if the parsed result contains a 'path'. If it does not than the rest of the if statement is ignored and no error is generated.