### PR TITLE
Fix strange behaviour with alpha PNG images since 6.2.22.

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6844,10 +6844,6 @@ class TCPDF {
 				$file = substr($file, 1);
 				$exurl = $file;
 			}
-			// check if file exist and it is valid
-			if (!@TCPDF_STATIC::file_exists($file)) {
-				return false;
-			}
 			if (($imsize = @getimagesize($file)) === FALSE) {
 				if (in_array($file, $this->imagekeys)) {
 					// get existing image data


### PR DESCRIPTION
I had a problem with the images in the headers and footers that are updated to the latest version of TCPDF.

I noticed that the problem started from version 6.2.22.

The error is really strange and only affects the PNG alpha images in some specific circumstances.

When the WriteHtml method is used and the HTML has a label like 'nobr = "true"', there is a forced page break so that the HTML element is not split into two pages.

It seems that the forced page break deletes some temporary images created by TCPDF when a PNG image is used in headers and footers.

The result is that the following pages after the 'writeHtml' call will not have the header and footer images added.

The error can be reproduced using the attachment [example_003b.php.txt](https://github.com/tecnickcom/TCPDF/files/3236190/example_003b.php.txt).

Debugging the changes between versions, I found that a 'return false' was introduced int versión 6.2.22 about line 6850 of 'tcpdf.php'. Deleting it fix this problem, but I don't know if it was introduced by another reason or by error, cause the if clause was empty after other changes.


