### PR TITLE
Fix a type casting warning

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1800,7 +1800,7 @@ class TCPDF_FONTS {
 		}
 		$string = '';
 		for ($i = $start; $i < $end; ++$i) {
-			$string .= self::unichr($strarr[$i], $unicode);
+			$string .= self::unichr((int) $strarr[$i], $unicode);
 		}
 		return $string;
 	}


### PR DESCRIPTION
This actually comes from phpMyAdmin with PHP 7.4-dev.



