### PR TITLE
Fix a warning for PHP 7.4

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -1960,7 +1960,7 @@ class TCPDF {
 		// set default JPEG quality
 		$this->jpeg_quality = 75;
 		// initialize some settings
-		TCPDF_FONTS::utf8Bidi(array(''), '', false, $this->isunicode, $this->CurrentFont);
+		TCPDF_FONTS::utf8Bidi(array(), '', false, $this->isunicode, $this->CurrentFont);
 		// set default font
 		$this->SetFont($this->FontFamily, $this->FontStyle, $this->FontSizePt);
 		$this->setHeaderFont(array($this->FontFamily, $this->FontStyle, $this->FontSizePt));


### PR DESCRIPTION
## Environments

- PHP `7.4.0 alpha 1`
- TCPDF `6.2.26`


## Issue

The constructor of `TCPDF` causes a warning in PHP 7.4 (currently still under dev). It's fine in 7.3 and former versions.

```
Warning: chr() expects parameter 1 to be int, string given in C:\Users\Clover\Desktop\test\php\vendor\tecnickcom\tcpdf\include\tcpdf_fonts.php on line 1671
```

## Traceback

https://github.com/tecnickcom/TCPDF/blob/756908329d3ebf553d069f0dfede7a81a8229a4e/include/tcpdf_fonts.php#L1666

https://github.com/tecnickcom/TCPDF/blob/756908329d3ebf553d069f0dfede7a81a8229a4e/include/tcpdf_fonts.php#L1803

https://github.com/tecnickcom/TCPDF/blob/756908329d3ebf553d069f0dfede7a81a8229a4e/include/tcpdf_fonts.php#L2099

https://github.com/tecnickcom/TCPDF/blob/756908329d3ebf553d069f0dfede7a81a8229a4e/tcpdf.php#L1963

I don't see a reason why it's called with
`TCPDF_FONTS::utf8Bidi(array(''), '', false, $this->isunicode, $this->CurrentFont);`
rather than 
`TCPDF_FONTS::utf8Bidi(array(), '', false, $this->isunicode, $this->CurrentFont);`.


## Reproducer

```php
<?php

declare(strict_types=1);

require __DIR__ . '/vendor/autoload.php';

$pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
$pdf->AddPage();
$pdf->writeHTMLCell(0, 0, '', '', 'Hello World', 0, 1, 0, true, '', true);
$pdf->Output(__DIR__ . '/example_001.pdf', 'F');
```