### PR TITLE
Let file_exists work with the "file://"-extension too

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1858,7 +1858,7 @@ class TCPDF_STATIC {
 		if (preg_match('|^https?://|', $filename) == 1) {
 			return self::url_exists($filename);
 		}
-		if (strpos($filename, '://')) {
+		if (strpos($filename, '://') && !preg_match('|file://|', $filename)) {
 			return false; // only support http and https wrappers for security reasons
 		}
 		return @file_exists($filename);


### PR DESCRIPTION
Since "file://"-URLs are local files and basically the same as "/-" URLs they should be handled the same. Not doing this leads to errors for using HTML-Code in local instances.