### PR TITLE
file_get_contents

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1929,7 +1929,7 @@ class TCPDF_STATIC {
 				continue;
 			}
 			$ret = @file_get_contents($path);
-			if ($ret !== false) {
+			if ( $ret != false ) {
 			    return $ret;
 			}
 			// try to use CURL for URLs


### PR DESCRIPTION
return value should also be checked for a non-empty string