### PR TITLE
Fix for PHP 7.4

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1664,6 +1664,7 @@ class TCPDF_FONTS {
 	 * @public static
 	 */
 	public static function unichr($c, $unicode=true) {
+		$c = (int)$c;
 		if (!$unicode) {
 			return chr($c);
 		} elseif ($c <= 0x7F) {


### PR DESCRIPTION
Fix for PHP 7.4 error because of wrong type for argument (i.e. an empty string): "chr() expects parameter 1 to be int, string given".
Occurred i.e. when calling TCPDF->__construct('P', 'mm', 'A4', true, 'UTF-8').