### PR TITLE
fix Undefined property: GLPIPDF::$imagekeys

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7796,8 +7796,10 @@ class TCPDF {
 				}
 				closedir($handle);
 			}
-			foreach($this->imagekeys as $file) {
-				unlink($file);
+			if (isset($this->imagekeys)) {
+				foreach($this->imagekeys as $file) {
+					unlink($file);
+				}
 			}
 		}
 		$preserve = array(


### PR DESCRIPTION
```
  *** PHP Notice(8): Undefined property: GLPIPDF::$imagekeys
  *** PHP Warning(2): Invalid argument supplied for foreach()

```

P.S. GLPIPDF is a simple class extending TCDPF
https://github.com/glpi-project/glpi/blob/9.4/bugfixes/inc/glpipdf.class.php#L42