### PR TITLE
FIX SVGPath elliptical arc with rx/ry=0 + z should return to initial …

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23406,7 +23406,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 	 */
 	protected function SVGPath($d, $style='') {
 		if ($this->state != 2) {
-			 return;
+			return;
 		}
 		// set fill/stroke style
 		$op = TCPDF_STATIC::getPathPaintOperator($style, '');
@@ -23426,6 +23426,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 		$xmax = 0;
 		$ymin = 2147483647;
 		$ymax = 0;
+		$xinitial = 0;
+		$yinitial = 0;
 		$relcoord = false;
 		$minlen = (0.01 / $this->k); // minimum acceptable length (3 point)
 		$firstcmd = true; // used to print first point
@@ -23470,6 +23472,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 								if ($ck == 1) {
 									$this->_outPoint($x, $y);
 									$firstcmd = false;
+									$xinitial = $x;
+									$yinitial = $y;
 								} else {
 									$this->_outLine($x, $y);
 								}
@@ -23657,8 +23661,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 						if ((($ck + 1) % 7) == 0) {
 							$x0 = $x;
 							$y0 = $y;
-							$rx = abs($params[($ck - 6)]);
-							$ry = abs($params[($ck - 5)]);
+							$rx = max(abs($params[($ck - 6)]), .000000001);
+							$ry = max(abs($params[($ck - 5)]), .000000001);
 							$ang = -$rawparams[($ck - 4)];
 							$angle = deg2rad($ang);
 							$fa = $rawparams[($ck - 3)]; // large-arc-flag
@@ -23745,6 +23749,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 				}
 				case 'Z': {
 					$this->_out('h');
+					$x = $x0 = $xinitial;
+					$y = $y0 = $yinitial;
 					break;
 				}
 			}


### PR DESCRIPTION


Two fixes proposals into this PR :

- For a path like this one, which draw a simple "A" : 
```m 2594.06,816.219 h 318.11 l -159.34,302.461 z m -214.13,-220.84 322.58,590.951 h 105.67 l 328.19,-590.951 h -108.46 l -75.49,145.363 h -399.74 l -75.47,-145.363```
When the "z" command comes, the path closes and the coordinates should return back to the initial point coordinates 2594.06,816.219. See specs https://www.w3.org/TR/SVG/paths.html#PathDataMovetoCommands and https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand.
I added $xinitial and $yinitial to keep in memory this "initial point", and return back coordinates to it on "z". It worked for this case, please check if this causes no problem with mines/maxes.

Here is a link to the SVG image I embed into the TCPDF generator using imageSVG() :
http://next.pillot.fr/middle-z.svg
Into your browser : works well
Into a PDF : looks bad
Into a PDF, with my proposal : looks good

- I had a "warning division by zero" on some cases where softwares create 0 radiuses. A little round of it avoids these alerts (max(..., .000000001)).