### PR TITLE
Changes PageBreakTrigger in footer in order to make fitBlock work

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -3565,6 +3565,7 @@ class TCPDF {
 		$this->_out("\n");
 		if ($this->print_footer) {
 			$this->setGraphicVars($this->default_graphic_vars);
+			$this->PageBreakTrigger = $this->h;
 			$this->current_column = 0;
 			$this->num_columns = 1;
 			$temp_thead = $this->thead;
@@ -3596,6 +3597,7 @@ class TCPDF {
 		}
 		// restore graphic settings
 		$this->setGraphicVars($gvars);
+		$this->PageBreakTrigger = $gvars['PageBreakTrigger'];
 		$this->current_column = $gvars['current_column'];
 		$this->num_columns = $gvars['num_columns'];
 		// calculate footer length


### PR DESCRIPTION
When we are in the footer we should set `$this->PageBreakTrigger` to the page height in order to make `fitBlock` work. This is e.g. an issue if you want to render an image in the footer with the option `fitonpage` being set.