### PR TITLE
Update tcpdf_static.php

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1,9 +1,9 @@
 <?php
 //============================================================+
 // File name   : tcpdf_static.php
-// Version     : 1.1.3
+// Version     : 1.1.4
 // Begin       : 2002-08-03
-// Last Update : 2015-04-28
+// Last Update : 2019-11-01
 // Author      : Nicola Asuni - Tecnick.com LTD - www.tecnick.com - info@tecnick.com
 // License     : GNU-LGPL v3 (http://www.gnu.org/copyleft/lesser.html)
 // -------------------------------------------------------------------
@@ -1829,6 +1829,8 @@ class TCPDF_STATIC {
 	 */
 	public static function url_exists($url) {
 		$crs = curl_init();
+		// encode query params in URL to get right response form the server
+		$url = self::encodeUrlQuery($url);
 		curl_setopt($crs, CURLOPT_URL, $url);
 		curl_setopt($crs, CURLOPT_NOBODY, true);
 		curl_setopt($crs, CURLOPT_FAILONERROR, true);
@@ -1844,6 +1846,26 @@ class TCPDF_STATIC {
 		$code = curl_getinfo($crs, CURLINFO_HTTP_CODE);
 		curl_close($crs);
 		return ($code == 200);
+	}
+
+	/**
+	 * Encode query params in URL
+	 *
+	 * @param string $url
+	 * @return string
+	 * @since 6.3.3 (2019-11-01)
+	 * @public static
+	 */
+	public function encodeUrlQuery($url) {
+		$urlData = parse_url($url);
+		if (isset($urlData['query']) && $urlData['query']) {
+			$urlQueryData = [];
+			parse_str(urldecode($urlData['query']), $urlQueryData);
+			$updatedUrl = $urlData['scheme'] . '://' . $urlData['host'] . $urlData['path'] . '?' . http_build_query($urlQueryData);
+		} else {
+			$updatedUrl = $url;
+		}
+		return $updatedUrl;
 	}
 
 	/**

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1856,7 +1856,7 @@ class TCPDF_STATIC {
 	 * @since 6.3.3 (2019-11-01)
 	 * @public static
 	 */
-	public function encodeUrlQuery($url) {
+	public static function encodeUrlQuery($url) {
 		$urlData = parse_url($url);
 		if (isset($urlData['query']) && $urlData['query']) {
 			$urlQueryData = [];


### PR DESCRIPTION
There is an error response (code 400) for checking if file exists in `\TCPDF_STATIC::url_exists` when `$url` contain query parameters with special chars, including spaces. This is making image not available on PDF. This update helps to update url and encode query parameters for correct response.