### PR TITLE
Fix license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "pdf417",
     "barcodes"
   ],
-  "license": "LGPL-3.0-or-later",
+  "license": "LGPL-3.0-only",
   "authors": [
     {
       "name": "Nicola Asuni",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "pdf417",
     "barcodes"
   ],
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-or-later",
   "authors": [
     {
       "name": "Nicola Asuni",


### PR DESCRIPTION
As per the [`composer.json` specification](https://getcomposer.org/doc/04-schema.md#license) the license should be a proper identifier from the [SPDX License List](https://spdx.org/licenses/). For LGPL 3.0 or later the proper identifier is `LGPL-3.0-or-later`.
https://github.com/tecnickcom/TCPDF/blob/9fde7bb9b404b945e7ea88fb7eccd23d9a4e324b/LICENSE.TXT#L5-L8