### PR TITLE
Allow to use AWS S3 through a stream prefixer

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1815,7 +1815,7 @@ class TCPDF_STATIC {
 	public static function fopenLocal($filename, $mode) {
 		if (strpos($filename, '://') === false) {
 			$filename = 'file://'.$filename;
-		} elseif (stream_is_local($filename) !== true) {
+		} elseif (stream_is_local($filename) !== true && strpos($filename, 's3://') === false) {
 			return false;
 		}
 		return fopen($filename, $mode);


### PR DESCRIPTION
The problem:
`s3://alwins-test-bucket/app/labels/test.pdf` is not seen as a local disk to which you can write. Now I get the following error; `Unable to create output file: s3://alwins-test-bucket/app/labels/test.pdf`. That while streaming to S3 can be treated as a local disk.