### PR TITLE
Do not unlink original file !

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7798,7 +7798,7 @@ class TCPDF {
 			}
 			if (isset($this->imagekeys)) {
 				foreach($this->imagekeys as $file) {
-					unlink($file);
+					//unlink($file);
 				}
 			}
 		}


### PR DESCRIPTION
this function deletes the original file not a copy or a reference !
$this->imagekeys holds the complete path and filename of the file which should be embed, so its not advised to delete this  :)