### PR TITLE
Fixes #185, PHP7.3.5 warning "A non-numeric value encountered"

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -5396,6 +5396,9 @@ class TCPDF {
 				$s .= 'q '.$this->TextColor.' ';
 			}
 			// rendering mode
+			if (!isset($this->textstrokewidth) || !is_numeric($this->textstrokewidth)) {  // mike, 19/02/20, was getting FALSE in $this->textstrokewidth
+				$this->textstrokewidth = 0; 
+			}
 			$s .= sprintf('BT %d Tr %F w ET ', $this->textrendermode, ($this->textstrokewidth * $this->k));
 			// count number of spaces
 			$ns = substr_count($txt, chr(32));


### PR DESCRIPTION
$this->textstrokewidth will sometimes evaluate as FALSE.  Under older
PHP versions it silently re-evaluated as 0 or 0.0 when used in
multiplicaiton operation.  So, now setting to 0.0 when not numeric.