### PR TITLE
php7.3 and imagemask fatal error fix

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7787,7 +7787,7 @@ class TCPDF {
 			}
 			if (isset($this->imagekeys)) {
 				foreach($this->imagekeys as $file) {
-					if (strpos($file, K_PATH_CACHE) === 0) {
+					if (strpos($file, K_PATH_CACHE) === 0 && file_exists($file)) {
 						@unlink($file);
 					}
 				}


### PR DESCRIPTION
fixes

PHP message: PHP Fatal error:  Uncaught ErrorException: unlink(/tmp/__tcpdf_351ebd7891d67ccef6584da0eee7e6f5_imgmask_alpha_3fd2ef0623f637f931694c0b8e4c33df)