### PR TITLE
Changed [] to array() to maintain PHP 5.3 compat.

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1859,7 +1859,7 @@ class TCPDF_STATIC {
 	public static function encodeUrlQuery($url) {
 		$urlData = parse_url($url);
 		if (isset($urlData['query']) && $urlData['query']) {
-			$urlQueryData = [];
+			$urlQueryData = array();
 			parse_str(urldecode($urlData['query']), $urlQueryData);
 			$updatedUrl = $urlData['scheme'] . '://' . $urlData['host'] . $urlData['path'] . '?' . http_build_query($urlQueryData);
 		} else {


### PR DESCRIPTION
Only a small change to maintain PHP 5.3 compatibility.
PHP 5.3 is EOL for quite a long time, but still in use :(