### PR TITLE
Fix "undefined variable" if "helvetica" font not loaded in tcpdf.php

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -9860,7 +9860,7 @@ class TCPDF {
 				$out .= ' >> >>';
 			}
 			$font = $this->getFontBuffer('helvetica');
-			$out .= ' /DA (/F'.$font['i'].' 0 Tf 0 g)';
+			$out .= ' /DA (/F'.($font ? $font['i'] : '').' 0 Tf 0 g)';
 			$out .= ' /Q '.(($this->rtl)?'2':'0');
 			//$out .= ' /XFA ';
 			$out .= ' >>';


### PR DESCRIPTION
On line [line 9863](https://github.com/tecnickcom/TCPDF/blob/master/tcpdf.php#L9863) in tcpdf.php the variable `$font` may contain also `false` if helvetica font not loaded, which throws error.