### PR TITLE
Fix 'Constant xxx already defined'

### DIFF
--- a/config/tcpdf_config.php
+++ b/config/tcpdf_config.php
@@ -84,143 +84,198 @@
 /**
  * Generic name for a blank image.
  */
-define ('K_BLANK_IMAGE', '_blank.png');
+if (!defined('K_BLANK_IMAGE')) {
+    define('K_BLANK_IMAGE', '_blank.png');
+}
 
 /**
  * Page format.
  */
-define ('PDF_PAGE_FORMAT', 'A4');
+if (!defined('PDF_PAGE_FORMAT')) {
+    define('PDF_PAGE_FORMAT', 'A4');
+}
 
 /**
  * Page orientation (P=portrait, L=landscape).
  */
-define ('PDF_PAGE_ORIENTATION', 'P');
+if (!defined('PDF_PAGE_ORIENTATION')) {
+    define ('PDF_PAGE_ORIENTATION', 'P');
+}
 
 /**
  * Document creator.
  */
-define ('PDF_CREATOR', 'TCPDF');
+if (!defined('PDF_CREATOR')) {
+    define ('PDF_CREATOR', 'TCPDF');
+}
 
 /**
  * Document author.
  */
-define ('PDF_AUTHOR', 'TCPDF');
-
+if (!defined('PDF_AUTHOR')) {
+    define('PDF_AUTHOR', 'TCPDF');
+}
 /**
  * Header title.
  */
-define ('PDF_HEADER_TITLE', 'TCPDF Example');
+if (!defined('PDF_HEADER_TITLE')) {
+    define('PDF_HEADER_TITLE', 'TCPDF Example');
+}
 
 /**
  * Header description string.
  */
-define ('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
+if (!defined('PDF_HEADER_STRING')) {
+    define('PDF_HEADER_STRING', "by Nicola Asuni - Tecnick.com\nwww.tcpdf.org");
+}
 
 /**
  * Document unit of measure [pt=point, mm=millimeter, cm=centimeter, in=inch].
  */
-define ('PDF_UNIT', 'mm');
+if (!defined('PDF_UNIT')) {
+    define('PDF_UNIT', 'mm');
+}
 
 /**
  * Header margin.
  */
-define ('PDF_MARGIN_HEADER', 5);
+if (!defined('PDF_MARGIN_HEADER')) {
+    define('PDF_MARGIN_HEADER', 5);
+}
 
 /**
  * Footer margin.
  */
-define ('PDF_MARGIN_FOOTER', 10);
+if (!defined('PDF_MARGIN_FOOTER')) {
+    define('PDF_MARGIN_FOOTER', 10);
+}
 
 /**
  * Top margin.
  */
-define ('PDF_MARGIN_TOP', 27);
+if (!defined('PDF_MARGIN_TOP')) {
+    define('PDF_MARGIN_TOP', 27);
+}
 
 /**
  * Bottom margin.
  */
-define ('PDF_MARGIN_BOTTOM', 25);
+if (!defined('PDF_MARGIN_BOTTOM')) {
+    define('PDF_MARGIN_BOTTOM', 25);
+}
 
 /**
  * Left margin.
  */
-define ('PDF_MARGIN_LEFT', 15);
+if (!defined('PDF_MARGIN_LEFT')) {
+    define('PDF_MARGIN_LEFT', 15);
+}
 
 /**
  * Right margin.
  */
-define ('PDF_MARGIN_RIGHT', 15);
+if (!defined('PDF_MARGIN_RIGHT')) {
+    define('PDF_MARGIN_RIGHT', 15);
+}
 
 /**
  * Default main font name.
  */
-define ('PDF_FONT_NAME_MAIN', 'helvetica');
+if (!defined('PDF_FONT_NAME_MAIN')) {
+    define('PDF_FONT_NAME_MAIN', 'helvetica');
+}
 
 /**
  * Default main font size.
  */
-define ('PDF_FONT_SIZE_MAIN', 10);
+if (!defined('PDF_FONT_SIZE_MAIN')) {
+    define('PDF_FONT_SIZE_MAIN', 10);
+}
 
 /**
  * Default data font name.
  */
-define ('PDF_FONT_NAME_DATA', 'helvetica');
+if (!defined('PDF_FONT_NAME_DATA')) {
+    define('PDF_FONT_NAME_DATA', 'helvetica');
+}
 
 /**
  * Default data font size.
  */
-define ('PDF_FONT_SIZE_DATA', 8);
+if (!defined('PDF_FONT_SIZE_DATA')) {
+    define('PDF_FONT_SIZE_DATA', 8);
+}
 
 /**
  * Default monospaced font name.
  */
-define ('PDF_FONT_MONOSPACED', 'courier');
+if (!defined('PDF_FONT_MONOSPACED')) {
+    define('PDF_FONT_MONOSPACED', 'courier');
+}
 
 /**
  * Ratio used to adjust the conversion of pixels to user units.
  */
-define ('PDF_IMAGE_SCALE_RATIO', 1.25);
+if (!defined('PDF_IMAGE_SCALE_RATIO')) {
+    define('PDF_IMAGE_SCALE_RATIO', 1.25);
+}
 
 /**
  * Magnification factor for titles.
  */
-define('HEAD_MAGNIFICATION', 1.1);
+if (!defined('HEAD_MAGNIFICATION')) {
+    define('HEAD_MAGNIFICATION', 1.1);
+}
 
 /**
  * Height of cell respect font height.
  */
-define('K_CELL_HEIGHT_RATIO', 1.25);
+if (!defined('K_CELL_HEIGHT_RATIO')) {
+    define('K_CELL_HEIGHT_RATIO', 1.25);
+}
 
 /**
  * Title magnification respect main font size.
  */
-define('K_TITLE_MAGNIFICATION', 1.3);
+if (!defined('K_TITLE_MAGNIFICATION')) {
+    define('K_TITLE_MAGNIFICATION', 1.3);
+}
 
 /**
  * Reduction factor for small font.
  */
-define('K_SMALL_RATIO', 2/3);
+if (!defined('K_SMALL_RATIO')) {
+    define('K_SMALL_RATIO', 2 / 3);
+}
 
 /**
  * Set to true to enable the special procedure used to avoid the overlappind of symbols on Thai language.
  */
-define('K_THAI_TOPCHARS', true);
+if (!defined('K_THAI_TOPCHARS')) {
+    define('K_THAI_TOPCHARS', true);
+}
 
 /**
  * If true allows to call TCPDF methods using HTML syntax
  * IMPORTANT: For security reason, disable this feature if you are printing user HTML content.
  */
-define('K_TCPDF_CALLS_IN_HTML', false);
+if (!defined('K_TCPDF_CALLS_IN_HTML')) {
+    define('K_TCPDF_CALLS_IN_HTML', false);
+}
 
 /**
  * If true and PHP version is greater than 5, then the Error() method throw new exception instead of terminating the execution.
  */
-define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
+if (!defined('K_TCPDF_THROW_EXCEPTION_ERROR')) {
+    define('K_TCPDF_THROW_EXCEPTION_ERROR', false);
+}
 
 /**
  * Default timezone for datetime functions
  */
-define('K_TIMEZONE', 'UTC');
+if (!defined('K_TIMEZONE')) {
+    define('K_TIMEZONE', 'UTC');
+}
 
 //============================================================+
 // END OF FILE


### PR DESCRIPTION
I'm experiencing the following problems in my environment.

```
Constant K_BLANK_IMAGE already defined
```

I checked and found that the error is caused by the following two libraries.

https://github.com/tecnickcom/TCPDF
https://github.com/DALTCORE/lara-pdf-merger

The same constants are defined.

https://github.com/tecnickcom/TCPDF/blob/master/config/tcpdf_config.php#L87
https://github.com/DALTCORE/lara-pdf-merger/blob/2.0/src/LynX39/LaraPdfMerger/tcpdf/tcpdf_autoconfig.php#L128

Fixed to work when the same constant is defined multiple times.


I hope you can confirm this.


@nicolaasuni