### PR TITLE
Allow enabling local `file://` protocol

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -1832,6 +1832,14 @@ class TCPDF {
 	 */
 	protected $gdgammacache = array();
 
+	/**
+	 * Whether to allow local file path in image html tags, when prefixed with file://
+     *
+	 * @protected
+	 * @since 6.4 (2020-07-23)
+	 */
+	protected $allowLocalFiles = false;
+	
 	//------------------------------------------------------------
 	// METHODS
 	//------------------------------------------------------------
@@ -2934,6 +2942,18 @@ class TCPDF {
 	public function SetCreator($creator) {
 		$this->creator = $creator;
 	}
+
+	/**
+	 * Whether to allow local file path in image html tags, when prefixed with file://
+	 * 
+	 * @param $allowLocalFiles (bool) True, when local files should be allowed. Otherwise false.
+	 * @public
+	 * @since 6.3
+	 */
+	public function SetAllowLocalFiles($allowLocalFiles) {
+		$this->allowLocalFiles = (bool) $allowLocalFiles;
+	}
+
 
 	/**
 	 * Throw an exception or print an error message and die if the K_TCPDF_PARSER_THROW_EXCEPTION_ERROR constant is set to true.
@@ -18885,7 +18905,11 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 					// data stream
 					$imgsrc = '@'.base64_decode(substr($imgsrc, 1));
 					$type = '';
-				} else {
+				} elseif ( $this->allowLocalFiles && substr($imgsrc, 0, 7) === 'file://') {
+                    // get image type from a local file path
+                    $imgsrc = substr($imgsrc, 7);
+                    $type = TCPDF_IMAGES::getImageFileType($imgsrc);
+                } else {
 					if (($imgsrc[0] === '/') AND !empty($_SERVER['DOCUMENT_ROOT']) AND ($_SERVER['DOCUMENT_ROOT'] != '/')) {
 						// fix image path
 						$findroot = strpos($imgsrc, $_SERVER['DOCUMENT_ROOT']);

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -2948,7 +2948,7 @@ class TCPDF {
 	 * 
 	 * @param $allowLocalFiles (bool) True, when local files should be allowed. Otherwise false.
 	 * @public
-	 * @since 6.3
+	 * @since 6.4
 	 */
 	public function SetAllowLocalFiles($allowLocalFiles) {
 		$this->allowLocalFiles = (bool) $allowLocalFiles;


### PR DESCRIPTION
this PR re-adds the ability to use server-local file path in html `<img>`-tags which is a feature reported missing by many users in https://github.com/tecnickcom/TCPDF/commit/a5135e2cf02f8c935b71e9e7d676f0f1d31b1b9d#r30784872

I guess, this feature was removed with 6.2.25 for security reasons (nur offical statement given).
in cases where all html is generated on the server side and no user given inputs are used, we can safely allow using local files.


After this PR local files are still disallowed-by-default but can be enabled with `$pdf->SetAllowLocalFiles(true);` and html like
```html
<table>
  <tr>
    <td width="25"><br><br><img src="file:///cluster/www/www/files/customer/files/artfarbe/3/4/2/9/4/files/master_60x70.jpg" width="60" height="70" border="0" /></td>
    <td><br><br><br>royal</td>
  </tr>
</table>
```