### PR TITLE
temporary files never deleted

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7342,6 +7342,9 @@ class TCPDF {
 		$imgmask = $this->Image($tempfile_alpha, $x, $y, $w, $h, 'PNG', '', '', $resize, $dpi, '', true, false);
 		// embed image, masked with previously embedded mask
 		$this->Image($tempfile_plain, $x, $y, $w, $h, $type, $link, $align, $resize, $dpi, $palign, false, $imgmask);
+		// remove temp files
+		unlink($tempfile_alpha);
+		unlink($tempfile_plain);
 	}
 
 	/**


### PR DESCRIPTION
When creating PNG files, temporary file are not removed (search for __tcpdf_* in your temp directory). After this changes temp directory never has temporary files created by tcpdf