### PR TITLE
Indicate that TCPDF is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "homepage": "http://www.tcpdf.org/",
   "type": "library",
   "description": "TCPDF is a PHP class for generating PDF documents and barcodes.",
+  "abandoned": true,
   "keywords": [
     "PDF",
     "tcpdf",


### PR DESCRIPTION
By judging from the fact of indiscriminate and without explanation closing of pull requests without further communication, maybe at least tell the world the true status of this software: It is abandoned.

A few examples:
 - https://github.com/tecnickcom/TCPDF/pull/249
 - https://github.com/tecnickcom/TCPDF/pull/245
 - https://github.com/tecnickcom/TCPDF/pull/244
 - https://github.com/tecnickcom/TCPDF/pull/243
