### PR TITLE
Fix #267 -  Empty result for big reports with writeHTML()

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16354,7 +16354,7 @@ class TCPDF {
 		// create a special tag to contain the CSS array (used for table content)
 		$csstagarray = '<cssarray>'.htmlentities(json_encode($css)).'</cssarray>';
 		// remove head and style blocks
-		$html = preg_replace('/<head([^\>]*)>(.*?)<\/head>/siU', '', $html);
+		$html = preg_replace('/<head([^\>]*)>(.*)?<\/head>/siU', '', $html);
 		$html = preg_replace('/<style([^\>]*)>([^\<]*)<\/style>/isU', '', $html);
 		// define block tags
 		$blocktags = array('blockquote','br','dd','dl','div','dt','h1','h2','h3','h4','h5','h6','hr','li','ol','p','pre','ul','tcpdf','table','tr','td');


### PR DESCRIPTION
Fix issue #267

Optimized regular expressions, which fixed a bug with large HTML


Test code:

```php
 <?php
require_once __DIR__ . './vendor/tecnickcom/tcpdf/tcpdf.php';
$html = file_get_contents('./test.html');

$pdf = new TCPDF('L', PDF_UNIT, 'A2', true, 'UTF-8', false);

$pdf->AddPage();
$pdf->SetFont('helvetica', null, 12);

// output the HTML content
$pdf->writeHTML($html, true, false, true, false, '');
$pdf->Output('example.pdf', 'I');
```

test.html in zip archive:
[test.html.zip](https://github.com/tecnickcom/TCPDF/files/5123493/test.html.zip)



