### PR TITLE
Fix image file type for urls with query params

### DIFF
--- a/include/tcpdf_images.php
+++ b/include/tcpdf_images.php
@@ -77,10 +77,7 @@ class TCPDF_IMAGES {
 			}
 		}
 		if (empty($type)) {
-			$fileinfo = pathinfo($imgfile);
-			if (isset($fileinfo['extension']) AND (!TCPDF_STATIC::empty_string($fileinfo['extension']))) {
-				$type = strtolower(trim($fileinfo['extension']));
-			}
+            $type = strtolower(trim(pathinfo(parse_url($imgfile, PHP_URL_PATH), PATHINFO_EXTENSION)));
 		}
 		if ($type == 'jpg') {
 			$type = 'jpeg';


### PR DESCRIPTION
When an URL is given with query params, TCPDF is unable to determine it's extension. It will assume the entire string after "." is the extension.
I combined parse_url with path_info to retrieve the extenstion directly, if availabe.