### PR TITLE
Fix duplicate file retrieval

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -1832,6 +1832,14 @@ class TCPDF {
 	 */
 	protected $gdgammacache = array();
 
+    /**
+     * Cache array for file content
+     * @protected
+     * @var array
+     * @sinde 6.3.5 (2020-09-28)
+     */
+	protected $fileContentCache = array();
+
 	//------------------------------------------------------------
 	// METHODS
 	//------------------------------------------------------------
@@ -4863,7 +4871,7 @@ class TCPDF {
 		}
 		reset($this->embeddedfiles);
 		foreach ($this->embeddedfiles as $filename => $filedata) {
-			$data = TCPDF_STATIC::fileGetContents($filedata['file']);
+		    $data = $this->getCachedFileContents($filedata['file']);
 			if ($data !== FALSE) {
 				$rawsize = strlen($data);
 				if ($rawsize > 0) {
@@ -6886,7 +6894,7 @@ class TCPDF {
 					$info = $this->getImageBuffer($file);
 					$imsize = array($info['w'], $info['h']);
 				} elseif (strpos($file, '__tcpdf_'.$this->file_id.'_img') === FALSE) {
-					$imgdata = TCPDF_STATIC::fileGetContents($file);
+                    $imgdata = $this->getCachedFileContents($file);
 				}
 			}
 		}
@@ -7093,7 +7101,7 @@ class TCPDF {
 							$svgimg = substr($file, 1);
 						} else {
 							// get SVG file content
-							$svgimg = TCPDF_STATIC::fileGetContents($file);
+                            $svgimg = $this->getCachedFileContents($file);
 						}
 						if ($svgimg !== FALSE) {
 							// get width and height
@@ -14909,7 +14917,7 @@ class TCPDF {
 		if ($file[0] === '@') { // image from string
 			$data = substr($file, 1);
 		} else { // EPS/AI file
-			$data = TCPDF_STATIC::fileGetContents($file);
+            $data = $this->getCachedFileContents($file);
 		}
 		if ($data === FALSE) {
 			$this->Error('EPS file not found: '.$file);
@@ -16328,7 +16336,7 @@ class TCPDF {
 						$type = array();
 						if (preg_match('/href[\s]*=[\s]*"([^"]*)"/', $link, $type) > 0) {
 							// read CSS data file
-							$cssdata = TCPDF_STATIC::fileGetContents(trim($type[1]));
+                            $cssdata = $this->getCachedFileContents(trim($type[1]));
 							if (($cssdata !== FALSE) AND (strlen($cssdata) > 0)) {
 								$css = array_merge($css, TCPDF_STATIC::extractCSSproperties($cssdata));
 							}
@@ -22776,7 +22784,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 			$svgdata = substr($file, 1);
 		} else { // SVG file
 			$this->svgdir = dirname($file);
-			$svgdata = TCPDF_STATIC::fileGetContents($file);
+            $svgdata = $this->getCachedFileContents($file);
 		}
 		if ($svgdata === FALSE) {
 			$this->Error('SVG file not found: '.$file);
@@ -24570,6 +24578,14 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 	}
 
 	// --- END SVG METHODS -----------------------------------------------------
+
+    protected function getCachedFileContents($file)
+    {
+        if (!isset($this->fileContentCache[$file])) {
+            $this->fileContentCache[$file] = TCPDF_STATIC::fileGetContents($file);
+        }
+        return $this->fileContentCache[$file];
+    }
 
 } // END OF TCPDF CLASS
 

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6885,7 +6885,7 @@ class TCPDF {
 				$exurl = $file;
 			}
 			// check if file exist and it is valid
-			if (!@TCPDF_STATIC::file_exists($file)) {
+			if (!@$this->fileExists($file)) {
 				return false;
 			}
 			if (($imsize = @getimagesize($file)) === FALSE) {
@@ -24579,12 +24579,31 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 
 	// --- END SVG METHODS -----------------------------------------------------
 
+    /**
+     * Keeps files in memory, so it doesn't need to downloaded everytime in a loop
+     * @param string $file
+     * @return string
+     */
     protected function getCachedFileContents($file)
     {
         if (!isset($this->fileContentCache[$file])) {
             $this->fileContentCache[$file] = TCPDF_STATIC::fileGetContents($file);
         }
         return $this->fileContentCache[$file];
+    }
+
+    /**
+     * Make use of the file content cache, to avoid a lot of calls to an external server to see if a file exists
+     * @param string $file
+     * @return bool
+     */
+    protected function fileExists($file)
+    {
+        if (isset($this->fileContentCache[$file])) {
+            return true;
+        }
+
+        return TCPDF_STATIC::file_exists($file);
     }
 
 } // END OF TCPDF CLASS

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6888,15 +6888,11 @@ class TCPDF {
 			if (!@$this->fileExists($file)) {
 				return false;
 			}
-			if (($imsize = @getimagesize($file)) === FALSE) {
-				if (in_array($file, $this->imagekeys)) {
-					// get existing image data
-					$info = $this->getImageBuffer($file);
-					$imsize = array($info['w'], $info['h']);
-				} elseif (strpos($file, '__tcpdf_'.$this->file_id.'_img') === FALSE) {
-                    $imgdata = $this->getCachedFileContents($file);
-				}
-			}
+            if (false !== $info = $this->getImageBuffer($file)) {
+                $imsize = array($info['w'], $info['h']);
+            } elseif (($imsize = @getimagesize($file)) === FALSE && strpos($file, '__tcpdf_'.$this->file_id.'_img') === FALSE){
+                $imgdata = $this->getCachedFileContents($file);
+            }
 		}
 		if (!empty($imgdata)) {
 			// copy image to cache
@@ -24593,13 +24589,13 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
     }
 
     /**
-     * Make use of the file content cache, to avoid a lot of calls to an external server to see if a file exists
+     * Avoid multiple calls to an external server to see if a file exists
      * @param string $file
      * @return bool
      */
     protected function fileExists($file)
     {
-        if (isset($this->fileContentCache[$file])) {
+        if (isset($this->fileContentCache[$file]) || false !== $this->getImageBuffer($file)) {
             return true;
         }
 


### PR DESCRIPTION
I'm not sure if this is useful for the library outside of my project scope, but I noticed a lot of outgoing calls for the same files (we're generating printable PDF's).
I tried to minimize calls by saving file content to memory and checking if an image already exists in the image buffer.
Switching an if statement around, makes sure we check memory *before* we try to find the same info *again*.