### PR TITLE
Fix optionnal parameters declaration (PHP8)

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1995,7 +1995,7 @@ class TCPDF_FONTS {
 	 * @author Nicola Asuni
 	 * @public static
 	 */
-	public static function UTF8StringToArray($str, $isunicode=true, &$currentfont) {
+	public static function UTF8StringToArray($str, $isunicode=true, &$currentfont=array()) {
 		if ($isunicode) {
 			// requires PCRE unicode support turned on
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
@@ -2021,7 +2021,7 @@ class TCPDF_FONTS {
 	 * @since 3.2.000 (2008-06-23)
 	 * @public static
 	 */
-	public static function UTF8ToLatin1($str, $isunicode=true, &$currentfont) {
+	public static function UTF8ToLatin1($str, $isunicode=true, &$currentfont=array()) {
 		$unicode = self::UTF8StringToArray($str, $isunicode, $currentfont); // array containing UTF-8 unicode values
 		return self::UTF8ArrToLatin1($unicode);
 	}
@@ -2037,7 +2037,7 @@ class TCPDF_FONTS {
 	 * @since 1.53.0.TC005 (2005-01-05)
 	 * @public static
 	 */
-	public static function UTF8ToUTF16BE($str, $setbom=false, $isunicode=true, &$currentfont) {
+	public static function UTF8ToUTF16BE($str, $setbom=false, $isunicode=true, &$currentfont=array()) {
 		if (!$isunicode) {
 			return $str; // string is not in unicode
 		}
@@ -2057,7 +2057,7 @@ class TCPDF_FONTS {
 	 * @since 2.1.000 (2008-01-08)
 	 * @public static
 	 */
-	public static function utf8StrRev($str, $setbom=false, $forcertl=false, $isunicode=true, &$currentfont) {
+	public static function utf8StrRev($str, $setbom=false, $forcertl=false, $isunicode=true, &$currentfont=array()) {
 		return self::utf8StrArrRev(self::UTF8StringToArray($str, $isunicode, $currentfont), $str, $setbom, $forcertl, $isunicode, $currentfont);
 	}
 
@@ -2074,7 +2074,7 @@ class TCPDF_FONTS {
 	 * @since 4.9.000 (2010-03-27)
 	 * @public static
 	 */
-	public static function utf8StrArrRev($arr, $str='', $setbom=false, $forcertl=false, $isunicode=true, &$currentfont) {
+	public static function utf8StrArrRev($arr, $str='', $setbom=false, $forcertl=false, $isunicode=true, &$currentfont=array()) {
 		return self::arrUTF8ToUTF16BE(self::utf8Bidi($arr, $str, $forcertl, $isunicode, $currentfont), $setbom);
 	}
 
@@ -2090,7 +2090,7 @@ class TCPDF_FONTS {
 	 * @since 2.4.000 (2008-03-06)
 	 * @public static
 	 */
-	public static function utf8Bidi($ta, $str='', $forcertl=false, $isunicode=true, &$currentfont) {
+	public static function utf8Bidi($ta, $str='', $forcertl=false, $isunicode=true, &$currentfont=array()) {
 		// paragraph embedding level
 		$pel = 0;
 		// max level

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -2507,7 +2507,7 @@ class TCPDF_STATIC {
 	 * @since 5.0.010 (2010-05-17)
 	 * @public static
 	 */
-	public static function setPageBoxes($page, $type, $llx, $lly, $urx, $ury, $points=false, $k, $pagedim=array()) {
+	public static function setPageBoxes($page, $type, $llx, $lly, $urx, $ury, $points=false, $k=1, $pagedim=array()) {
 		if (!isset($pagedim[$page])) {
 			// initialize array
 			$pagedim[$page] = array();

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1136,7 +1136,7 @@ class TCPDF_STATIC {
 	 * @see setHtmlVSpace()
 	 * @public static
 	 */
-	public static function fixHTMLCode($html, $default_css='', $tagvs='', $tidy_options='', &$tagvspaces) {
+	public static function fixHTMLCode($html, $default_css='', $tagvs='', $tidy_options='', &$tagvspaces=array()) {
 		// configure parameters for HTML Tidy
 		if ($tidy_options === '') {
 			$tidy_options = array (


### PR DESCRIPTION
Some deprecation errors are trigerred when exporting a PDF in PHP 8. If these errors are displayed, it prevents sending valid PDF headers/contents to the browser.

Even if these params are always set in internal use of fixed methods, I kept their optionnal state as they are declared in public methods.

```
PHP Deprecated function (8192): Required parameter $currentfont follows optional parameter $isunicode in ./vendor/tecnickcom/tcpdf/include/tcpdf_fonts.php at line 1998
PHP Deprecated function (8192): Required parameter $currentfont follows optional parameter $isunicode in ./vendor/tecnickcom/tcpdf/include/tcpdf_fonts.php at line 2024
PHP Deprecated function (8192): Required parameter $currentfont follows optional parameter $setbom in ./vendor/tecnickcom/tcpdf/include/tcpdf_fonts.php at line 2040
PHP Deprecated function (8192): Required parameter $currentfont follows optional parameter $setbom in ./vendor/tecnickcom/tcpdf/include/tcpdf_fonts.php at line 2060
PHP Deprecated function (8192): Required parameter $currentfont follows optional parameter $str in ./vendor/tecnickcom/tcpdf/include/tcpdf_fonts.php at line 2077
PHP Deprecated function (8192): Required parameter $currentfont follows optional parameter $str in ./vendor/tecnickcom/tcpdf/include/tcpdf_fonts.php at line 2093
PHP Deprecated function (8192): Required parameter $tagvspaces follows optional parameter $default_css in ./vendor/tecnickcom/tcpdf/include/tcpdf_static.php at line 1139
PHP Deprecated function (8192): Required parameter $k follows optional parameter $points in ./vendor/tecnickcom/tcpdf/include/tcpdf_static.php at line 2510
```