### PR TITLE
FIX SVGPath should accept 1.19.30 (equiv 1.19,.30) compacted values list

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23418,6 +23418,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 		}
 		$paths = array();
 		$d = preg_replace('/([0-9ACHLMQSTVZ])([\-\+])/si', '\\1 \\2', $d);
+		$d = preg_replace('/(\.[0-9]+)(\.)/s', '\\1 \\2', $d);
 		preg_match_all('/([ACHLMQSTVZ])[\s]*([^ACHLMQSTVZ\"]*)/si', $d, $paths, PREG_SET_ORDER);
 		$x = 0;
 		$y = 0;


### PR DESCRIPTION
SVG path allows little values (<1) to follow-up without separator, like into this code :

```xml
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 674 133" width="674" height="133">
<path d="M118,133H91.6c8.79-2.37,19.45-5.51,21.35-6.46,7.06-3.53,8.68-7.41,8.68-20.78,0-.15.06-3.91,0-18.77" style="fill:#04b497"/>
</svg>
```

This part of the path is not well interpreted by the SVGPath() function : `-.15.06`

- should equiv `-.15 .06`
- is treated as `-.15`. The next value `.06` is ignored and the number are shifted and everything goes wrong

Some svg files may encouter this issue. You can get a full svg example file here :
http://next.pillot.fr/compact-svg-logo.svg
It looks well into the browser, but is ruined by tcpdf.
This commit is a proposal that solves the problem adding a space separator into paths.