### PR TITLE
Fix vulnerability to roman numeral bombs

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1440,6 +1440,10 @@ class TCPDF_STATIC {
 	 */
 	public static function intToRoman($number) {
 		$roman = '';
+		if ($number >= 4000) {
+			// do not represent numbers above 4000 in Roman numerals
+			return strval($number);
+		}
 		while ($number >= 1000) {
 			$roman .= 'M';
 			$number -= 1000;


### PR DESCRIPTION
# Issue
Consider this bit of HTML:
```html
<ol type="i">
<li value="50000">this is a (small) bomb</li>
</ol>
```
Web browsers are don't display roman numerals above 3999, but TCPDF does, so `intToRoman(50000)` will return `mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm`.

This is not so bad with `50000` (only 50 bytes), but one of our clients had a `<li>` with a value attribute of more than 32000000000 in a similar (and apparently unintentional) bit of HTML that was passed to `writeHTMLCell()`, resulting in a memory allocation error.

According to the English language Wikipedia as it stands at the time of this PR (https://en.wikipedia.org/wiki/Roman_numerals#Standard_form), 3999 is the largest number that can be represented in the standard form of roman numerals.

Since this is my very first contribution to the project, this PR may not be up to TCPDF's standards. If this is the case, please tell me how to improve it.