### PR TITLE
Curl Security: Limit protocols and redirects

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1842,6 +1842,10 @@ class TCPDF_STATIC {
 		curl_setopt($crs, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($crs, CURLOPT_SSL_VERIFYHOST, false);
 		curl_setopt($crs, CURLOPT_USERAGENT, 'tc-lib-file');
+		curl_setopt($crs, CURLOPT_MAXREDIRS, 5);
+		if (defined('CURLOPT_PROTOCOLS')) {
+		    curl_setopt($crs, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP |  CURLPROTO_FTP | CURLPROTO_FTPS);
+		}
 		curl_exec($crs);
 		$code = curl_getinfo($crs, CURLINFO_HTTP_CODE);
 		curl_close($crs);
@@ -1973,6 +1977,10 @@ class TCPDF_STATIC {
 				curl_setopt($crs, CURLOPT_SSL_VERIFYPEER, false);
 				curl_setopt($crs, CURLOPT_SSL_VERIFYHOST, false);
 				curl_setopt($crs, CURLOPT_USERAGENT, 'tc-lib-file');
+				curl_setopt($crs, CURLOPT_MAXREDIRS, 5);
+				if (defined('CURLOPT_PROTOCOLS')) {
+				    curl_setopt($crs, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP |  CURLPROTO_FTP | CURLPROTO_FTPS);
+				}
 				$ret = curl_exec($crs);
 				curl_close($crs);
 				if ($ret !== false) {


### PR DESCRIPTION
In `include/tcpdf_static.php` file, there are couple Curl calls that could use some additional Curl hardening.

1. Limit the maximum number of redirects Curl is allowed to follow. Currently, it is configured in PHP source code to 20. However, as a [security precaution, limit it to 5](https://php.watch/articles/php-curl-security-hardening#infinite-redirects).

2. Curl is used here for HTTP, HTTPS, and in one instance, for FTP URLs. With `CURLOPT_FOLLOWLOCATION` option enabled, this allows a malicious remote server to perform SSRF attacks and utilize all protocols Curl supports, such as LDAP, FTP, etc that are highly undesired. Setting a restricted [`CURLOPT_PROTOCOLS` value mitigates this vulnerability](https://php.watch/articles/php-curl-security-hardening#ssrf). In older Curl versions, it even allows local file inclusion attacks with `file:///etc/passwd` style redirect URLs.