### PR TITLE
check if file exists before calling unlink

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7806,7 +7806,7 @@ class TCPDF {
 			}
 			if (isset($this->imagekeys)) {
 				foreach($this->imagekeys as $file) {
-					if (strpos($file, K_PATH_CACHE) === 0 && file_exists($file)) {
+					if (strpos($file, K_PATH_CACHE) === 0 && TCPDF_STATIC::file_exists($file)) {
 						@unlink($file);
 					}
 				}

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7793,7 +7793,7 @@ class TCPDF {
 			}
 			if (isset($this->imagekeys)) {
 				foreach($this->imagekeys as $file) {
-					if (strpos($file, K_PATH_CACHE) === 0) {
+					if (strpos($file, K_PATH_CACHE) === 0 && file_exists($file)) {
 						@unlink($file);
 					}
 				}


### PR DESCRIPTION
When running a Symfony command that uses tcpdf.php, the process always returns with exit code 255. The check for `file_exists()` prevents that.

For some reason, the file is being deleted just a few lines before, see here:
```
if ($handle = @opendir(K_PATH_CACHE)) {
  while ( false !== ( $file_name = readdir( $handle ) ) ) {
    if (strpos($file_name, '__tcpdf_'.$this->file_id.'_') === 0) {
      unlink(K_PATH_CACHE.$file_name); // file is deleted here
    }
  }
  closedir($handle);
}
if (isset($this->imagekeys)) {
  foreach($this->imagekeys as $file) {
    if (strpos($file, K_PATH_CACHE) === 0) {
      @unlink($file); // error is silenced, but still exit code 255 is the result
    }
  }
}
```

I added a simple `file_exists()` to prevent this from happening.