### PR TITLE
PHP 8.1: Fix implicit conversion from float to int

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -4179,8 +4179,8 @@ class TCPDF {
 			// SHY character will not be printed
 			return (0);
 		}
-		if (isset($this->CurrentFont['cw'][$char])) {
-			$w = $this->CurrentFont['cw'][$char];
+		if (isset($this->CurrentFont['cw'][intval($char)])) {
+			$w = $this->CurrentFont['cw'][intval($char)];
 		} elseif (isset($this->CurrentFont['dw'])) {
 			// default width
 			$w = $this->CurrentFont['dw'];


### PR DESCRIPTION
Fixes PHP 8.1 deprecation notice: Implicit conversion from float to int loses precision.

- [PHP RFC: Deprecate implicit non-integer-compatible float to int conversions](https://wiki.php.net/rfc/implicit-float-int-deprecate).
- https://github.com/phpmyadmin/phpmyadmin/runs/2806644704#step:10:35

```
PHP Deprecated:  Implicit conversion from float 1.1768666666666663 to int loses precision in /home/runner/work/phpmyadmin/phpmyadmin/vendor/tecnickcom/tcpdf/tcpdf.php on line 4179
PHP Deprecated:  Implicit conversion from float 1.1768666666666663 to int loses precision in /home/runner/work/phpmyadmin/phpmyadmin/vendor/tecnickcom/tcpdf/tcpdf.php on line 4180
```