### PR TITLE
Leave &NBSP; lowercase when using text-transform

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -17129,6 +17129,7 @@ class TCPDF {
 							}
 						}
 					}
+					$element = preg_replace("/&NBSP;/i", "&nbsp;", $element);
 				}
 				$dom[$key]['value'] = stripslashes($this->unhtmlentities($element));
 			}


### PR DESCRIPTION
When using text-transform: uppercase, convert "&NBSP;" back to lowercase "&nbsp;" so that it is recognized as a space by Adobe Acrobat rather than printing out "&NBSP;"