### PR TITLE
Fix cell_height_ratio type

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -918,6 +918,7 @@ class TCPDF {
 	 * Default cell height ratio.
 	 * @protected
 	 * @since 3.0.014 (2008-05-23)
+	 * @var float
 	 */
 	protected $cell_height_ratio = K_CELL_HEIGHT_RATIO;
 
@@ -2449,6 +2450,7 @@ class TCPDF {
 	 * @param int $fontsize Font size in internal units
 	 * @param boolean $padding If true add cell padding
 	 * @public
+	 * @return float
 	 */
 	public function getCellHeight($fontsize, $padding=TRUE) {
 		$height = ($fontsize * $this->cell_height_ratio);
@@ -14062,7 +14064,7 @@ class TCPDF {
 
 	/**
 	 * Set the height of the cell (line height) respect the font height.
-	 * @param int $h cell proportion respect font height (typical value = 1.25).
+	 * @param float $h cell proportion respect font height (typical value = 1.25).
 	 * @public
 	 * @since 3.0.014 (2008-06-04)
 	 */
@@ -14073,6 +14075,7 @@ class TCPDF {
 	/**
 	 * return the height of cell repect font height.
 	 * @public
+	 * @return float
 	 * @since 4.0.012 (2008-07-24)
 	 */
 	public function getCellHeightRatio() {


### PR DESCRIPTION
Changed from `int` to `float`, I've also added some related type declaration info.

It is initialized to `1.25`

https://github.com/tecnickcom/TCPDF/blob/456b794f1fae9aee5c151a1ee515aae2aaa619a3/examples/config/tcpdf_config_alt.php#L192