### PR TITLE
fix text-annotation state options

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -8416,8 +8416,13 @@ class TCPDF {
 							} else {
 								$annots .= ' /Name /Note';
 							}
+							$hasStateModel = isset($pl['opt']['statemodel']);
+							$hasState = isset($pl['opt']['state']); 
 							$statemodels = array('Marked', 'Review');
-							if (isset($pl['opt']['statemodel']) AND in_array($pl['opt']['statemodel'], $statemodels)) {
+							if (!$hasStateModel && !$hasState) {
+								break;
+							}
+							if ($hasStateModel AND in_array($pl['opt']['statemodel'], $statemodels)) {
 								$annots .= ' /StateModel /'.$pl['opt']['statemodel'];
 							} else {
 								$pl['opt']['statemodel'] = 'Marked';
@@ -8428,7 +8433,7 @@ class TCPDF {
 							} else {
 								$states = array('Accepted', 'Rejected', 'Cancelled', 'Completed', 'None');
 							}
-							if (isset($pl['opt']['state']) AND in_array($pl['opt']['state'], $states)) {
+							if ($hasState AND in_array($pl['opt']['state'], $states)) {
 								$annots .= ' /State /'.$pl['opt']['state'];
 							} else {
 								if ($pl['opt']['statemodel'] == 'Marked') {


### PR DESCRIPTION
Hello.
Fix for #411 

I did not change the current conditions, just turned off the setting of the Statе and StateModel parameters for text annotations, if they are not explicitly specified.
According to PDF specification 1.7, these parameters are optional.