### PR TITLE
Fix type hint for \TCPDF_STATIC::_freadint

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -2133,7 +2133,7 @@ class TCPDF_STATIC {
 
 	/**
 	 * Read a 4-byte (32 bit) integer from file.
-	 * @param string $f file name.
+	 * @param resource $f file resource.
 	 * @return int 4-byte integer
 	 * @public static
 	 */


### PR DESCRIPTION
A resource, not a string expected for param `$f`