### PR TITLE
Allow phar urls usage in file_exists method to fix font loading from phar app

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1898,8 +1898,8 @@ class TCPDF_STATIC {
 		if (preg_match('|^https?://|', $filename) == 1) {
 			return self::url_exists($filename);
 		}
-		if (strpos($filename, '://')) {
-			return false; // only support http and https wrappers for security reasons
+		if (!preg_match('|^phar://|', $filename) && strpos($filename, '://')) {
+			return false; // only support phar, http and https wrappers for security reasons
 		}
 		return @file_exists($filename);
 	}


### PR DESCRIPTION
As it is referred by issue  #371, TCPF breaks inside phar because the internal file_exist method disallow anything except local, http and https protocols. Whenever TCPDF tries to load a font, it then fails with message "Could not include font definition file: helvetica". This P.R solves the problem by including the phar protocol to the list (phar://). 