### PR TITLE
Fix AES128 encryption if the OpenSSL extension is installed

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -449,8 +449,13 @@ class TCPDF_STATIC {
 		$padding = 16 - (strlen($text) % 16);
 		$text .= str_repeat(chr($padding), $padding);
 		if (extension_loaded('openssl')) {
-			$iv = openssl_random_pseudo_bytes (openssl_cipher_iv_length('aes-256-cbc'));
-			$text = openssl_encrypt($text, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+			if (strlen($key) == 16) {
+				$algo = 'aes-128-cbc';
+			} else {
+				$algo = 'aes-256-cbc';
+			}
+			$iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length($algo));
+			$text = openssl_encrypt($text, $algo, $key, OPENSSL_RAW_DATA, $iv);
 			return $iv.substr($text, 0, -16);
 		}
 		$iv = mcrypt_create_iv(mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC), MCRYPT_RAND);
@@ -471,8 +476,13 @@ class TCPDF_STATIC {
 	 */
 	public static function _AESnopad($key, $text) {
 		if (extension_loaded('openssl')) {
-			$iv = str_repeat("\x00", openssl_cipher_iv_length('aes-256-cbc'));
-			$text = openssl_encrypt($text, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+			if (strlen($key) == 16) {
+				$algo = 'aes-128-cbc';
+			} else {
+				$algo = 'aes-256-cbc';
+			}
+			$iv = str_repeat("\x00", openssl_cipher_iv_length($algo));
+			$text = openssl_encrypt($text, $algo, $key, OPENSSL_RAW_DATA, $iv);
 			return substr($text, 0, -16);
 		}
 		$iv = str_repeat("\x00", mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC));

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -449,10 +449,9 @@ class TCPDF_STATIC {
 		$padding = 16 - (strlen($text) % 16);
 		$text .= str_repeat(chr($padding), $padding);
 		if (extension_loaded('openssl')) {
+			$algo = 'aes-256-cbc';
 			if (strlen($key) == 16) {
 				$algo = 'aes-128-cbc';
-			} else {
-				$algo = 'aes-256-cbc';
 			}
 			$iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length($algo));
 			$text = openssl_encrypt($text, $algo, $key, OPENSSL_RAW_DATA, $iv);
@@ -476,10 +475,9 @@ class TCPDF_STATIC {
 	 */
 	public static function _AESnopad($key, $text) {
 		if (extension_loaded('openssl')) {
+			$algo = 'aes-256-cbc';
 			if (strlen($key) == 16) {
 				$algo = 'aes-128-cbc';
-			} else {
-				$algo = 'aes-256-cbc';
 			}
 			$iv = str_repeat("\x00", openssl_cipher_iv_length($algo));
 			$text = openssl_encrypt($text, $algo, $key, OPENSSL_RAW_DATA, $iv);


### PR DESCRIPTION
This patch fixes generating of AES128 (mode=2) encrypted PDF files, if the OpenSSL extension is available.

If OpenSSL available TCPDF used aes-256-cbc regardless if mode=2 oder mode=3 was selected - which resulted in an unusable PDF file.
Now the functions _AES and _AESnopad use aes-128-cbc or aes-256-cbc depending on the key size.