### PR TITLE
[php 8.1] fix deprecation notice for imagesetpixel

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7357,7 +7357,7 @@ class TCPDF {
 						$color = imagecolorat($img, $xpx, $ypx);
 						// get and correct gamma color
 						$alpha = $this->getGDgamma($img, $color);
-						imagesetpixel($imgalpha, $xpx, $ypx, $alpha);
+						imagesetpixel($imgalpha, (int) $xpx, (int) $ypx, (int) $alpha);
 					}
 				}
 				imagepng($imgalpha, $tempfile_alpha);


### PR DESCRIPTION
#459 

```
[2021-12-20T11:15:04.984791+00:00] php.INFO: Deprecated: Implicit conversion from float 0.5820629629409302 to int loses precision {"exception":"[object] (ErrorException(code: 0): Deprecated: Implicit conversion from float 0.5820629629409302 to int loses precision at /var/www/svm/vendor/tecnickcom/tcpdf/tcpdf.php:7360)"} []
```