### PR TITLE
GetCssBorderStyle Has Problem When !important Is Specified

### DIFF
--- a/examples/example_067.php
+++ b/examples/example_067.php
@@ -1,0 +1,151 @@
+<?php
+//============================================================+
+// File name   : example_067.php
+// Begin       : 2022-01-07
+// Last Update : 2022-01-07
+//
+// Description : Example 067 for TCPDF class
+//               HTML tables with !important in style
+//
+// Author: Nicola Asuni
+//
+// (c) Copyright:
+//               Nicola Asuni
+//               Tecnick.com LTD
+//               www.tecnick.com
+//               info@tecnick.com
+//============================================================+
+
+/**
+ * Creates an example PDF TEST document using TCPDF
+ * @package com.tecnick.tcpdf
+ * @abstract TCPDF - Example: HTML tables and table headers
+ * @author Nicola Asuni
+ * @since 2009-03-20
+ */
+
+// Include the main TCPDF library (search for installation path).
+require_once('tcpdf_include.php');
+
+// create new PDF document
+$pdf = new TCPDF(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
+
+// set document information
+$pdf->setCreator(PDF_CREATOR);
+$pdf->setAuthor('Owen Leibman');
+$pdf->setTitle('TCPDF Example 067');
+$pdf->setSubject('TCPDF Tutorial');
+$pdf->setKeywords('TCPDF, PDF, example, test, guide');
+
+// set default header data
+$pdf->setHeaderData(PDF_HEADER_LOGO, PDF_HEADER_LOGO_WIDTH, PDF_HEADER_TITLE.' 067', PDF_HEADER_STRING);
+
+// set header and footer fonts
+$pdf->setHeaderFont(Array(PDF_FONT_NAME_MAIN, '', PDF_FONT_SIZE_MAIN));
+$pdf->setFooterFont(Array(PDF_FONT_NAME_DATA, '', PDF_FONT_SIZE_DATA));
+
+// set default monospaced font
+$pdf->setDefaultMonospacedFont(PDF_FONT_MONOSPACED);
+
+// set margins
+$pdf->setMargins(PDF_MARGIN_LEFT, PDF_MARGIN_TOP, PDF_MARGIN_RIGHT);
+$pdf->setHeaderMargin(PDF_MARGIN_HEADER);
+$pdf->setFooterMargin(PDF_MARGIN_FOOTER);
+
+// set auto page breaks
+$pdf->setAutoPageBreak(TRUE, PDF_MARGIN_BOTTOM);
+
+// set image scale factor
+$pdf->setImageScale(PDF_IMAGE_SCALE_RATIO);
+
+// set some language-dependent strings (optional)
+if (@file_exists(dirname(__FILE__).'/lang/eng.php')) {
+	require_once(dirname(__FILE__).'/lang/eng.php');
+	$pdf->setLanguageArray($l);
+}
+
+// ---------------------------------------------------------
+
+// set font
+$pdf->setFont('helvetica', 'B', 20);
+
+// add a page
+$pdf->AddPage();
+
+$pdf->Write(0, 'Example of HTML tables', '', 0, 'L', true, 0, false, false, 0);
+
+$pdf->setFont('helvetica', '', 8);
+
+// -----------------------------------------------------------------------------
+
+$tbl = <<<EOD
+<table cellspacing="0" cellpadding="1" style="border: 5px solid red;">
+    <tr>
+        <td rowspan="3">COL 1 - ROW 1<br />COLSPAN 3</td>
+        <td>COL 2 - ROW 1</td>
+        <td>COL 3 - ROW 1</td>
+    </tr>
+    <tr>
+    	<td rowspan="2">COL 2 - ROW 2 - COLSPAN 2<br />text line<br />text line<br />text line<br />text line</td>
+    	<td>COL 3 - ROW 2</td>
+    </tr>
+    <tr>
+       <td>COL 3 - ROW 3</td>
+    </tr>
+
+</table>
+EOD;
+
+$pdf->writeHTML($tbl, true, false, false, false, '');
+
+// -----------------------------------------------------------------------------
+
+$tbl = <<<EOD
+<table cellspacing="0" cellpadding="1" style="border: 5px solid blue !important;">
+    <tr>
+        <td rowspan="3">COL 1 - ROW 1<br />COLSPAN 3</td>
+        <td>COL 2 - ROW 1</td>
+        <td>COL 3 - ROW 1</td>
+    </tr>
+    <tr>
+    	<td rowspan="2">COL 2 - ROW 2 - COLSPAN 2<br />text line<br />text line<br />text line<br />text line</td>
+    	<td>COL 3 - ROW 2</td>
+    </tr>
+    <tr>
+       <td>COL 3 - ROW 3</td>
+    </tr>
+
+</table>
+EOD;
+
+$pdf->writeHTML($tbl, true, false, false, false, '');
+
+// -----------------------------------------------------------------------------
+
+$tbl = <<<EOD
+<table cellspacing="0" cellpadding="1" style="border: 1px hair black !important;">
+    <tr>
+        <td rowspan="3">COL 1 - ROW 1<br />COLSPAN 3</td>
+        <td>COL 2 - ROW 1</td>
+        <td>COL 3 - ROW 1</td>
+    </tr>
+    <tr>
+    	<td rowspan="2">COL 2 - ROW 2 - COLSPAN 2<br />text line<br />text line<br />text line<br />text line</td>
+    	<td>COL 3 - ROW 2</td>
+    </tr>
+    <tr>
+       <td>COL 3 - ROW 3</td>
+    </tr>
+
+</table>
+EOD;
+
+$pdf->writeHTML($tbl, true, false, false, false, '');
+// -----------------------------------------------------------------------------
+
+//Close and output PDF document
+$pdf->Output('example_067.pdf', 'I');
+
+//============================================================+
+// END OF FILE
+//============================================================+

--- a/examples/index.php
+++ b/examples/index.php
@@ -85,6 +85,8 @@ echo '<'.'?'.'xml version="1.0" encoding="UTF-8"'.'?'.'>';
 <li>Text stretching and spacing (tracking/kerning): [<a href="example_063.php" title="PDF [new window]" target="_blank">PDF</a>]</li>
 <li>No-write page regions: [<a href="example_064.php" title="PDF [new window]" target="_blank">PDF</a>]</li>
 <li>PDF/A-1b (ISO 19005-1:2005) document: [<a href="example_065.php" title="PDF [new window]" target="_blank">PDF</a>]</li>
+<li>Using WriteHTMLCell: [<a href="example_066.php" title="PDF [new window]" target="_blank">PDF</a>]</li>
+<li>Shorthand border styles including !important: [<a href="example_067.php" title="PDF [new window]" target="_blank">PDF</a>]</li>
 </ol>
 
 <h2>Barcodes</h2>

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16019,12 +16019,6 @@ class TCPDF {
 		$bprop = preg_split('/[\s]+/', trim($cssborder));
 		$border = array(); // value to be returned
 		switch (count($bprop)) {
-			case 3: {
-				$width = $bprop[0];
-				$style = $bprop[1];
-				$color = $bprop[2];
-				break;
-			}
 			case 2: {
 				$width = 'medium';
 				$style = $bprop[0];
@@ -16037,10 +16031,16 @@ class TCPDF {
 				$color = 'black';
 				break;
 			}
-			default: {
+			case 0: {
 				$width = 'medium';
 				$style = 'solid';
 				$color = 'black';
+				break;
+			}
+			default: {
+				$width = $bprop[0];
+				$style = $bprop[1];
+				$color = $bprop[2];
 				break;
 			}
 		}


### PR DESCRIPTION
This is, in particular, a problem for PhpSpreadsheet. See https://github.com/PHPOffice/PhpSpreadsheet/issues/1164. TCPDF thinks that there can be 0, 1, 2, or 3 components to shorthand border style, but there can be more, e.g. !important. Logic is rearranged to allow for more than 3. A new example file is added to demonstrate that the fix works correctly.