### PR TITLE
Fix Infinite Loop in Multicell with Auto Page Breaks Off

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6495,14 +6495,16 @@ class TCPDF {
 				$shy = false;
 				// account for margin changes
 				if ((($this->y + $this->lasth) > $this->PageBreakTrigger) AND ($this->inPageBody())) {
-					$this->AcceptPageBreak();
-					if ($this->rtl) {
-						$this->x -= $margin['R'];
-					} else {
-						$this->x += $margin['L'];
+					if ($this->AcceptPageBreak())
+					{
+						if ($this->rtl) {
+							$this->x -= $margin['R'];
+						} else {
+							$this->x += $margin['L'];
+						}
+						$this->lMargin += $margin['L'];
+						$this->rMargin += $margin['R'];
 					}
-					$this->lMargin += $margin['L'];
-					$this->rMargin += $margin['R'];
 				}
 				$w = $this->getRemainingWidth();
 				$wmax = ($w - $this->cell_padding['L'] - $this->cell_padding['R']);
@@ -6700,14 +6702,16 @@ class TCPDF {
 					}
 					// account for margin changes
 					if ((($this->y + $this->lasth) > $this->PageBreakTrigger) AND ($this->inPageBody())) {
-						$this->AcceptPageBreak();
-						if ($this->rtl) {
-							$this->x -= $margin['R'];
-						} else {
-							$this->x += $margin['L'];
+						if ($this->AcceptPageBreak())
+						{
+							if ($this->rtl) {
+								$this->x -= $margin['R'];
+							} else {
+								$this->x += $margin['L'];
+							}
+							$this->lMargin += $margin['L'];
+							$this->rMargin += $margin['R'];
 						}
-						$this->lMargin += $margin['L'];
-						$this->rMargin += $margin['R'];
 					}
 					$w = $this->getRemainingWidth();
 					$wmax = $w - $this->cell_padding['L'] - $this->cell_padding['R'];


### PR DESCRIPTION
The updated places that used `AcceptPageBreak` assumed that a page break was added and increased X by the margin.  However, if the break wasn't added, it would put the text further to the right to the point that the width because so small or negative and no characters fit, causing an infinite loop.

# Example File
```php
<?php

require_once('tcpdf_include.php');

class MYPDF extends TCPDF
{
	public function crash()
	{
		$width = 140;
		$val = '';
		for ($i = 1; $i <= 100; $i++)
			$val .= "Line $i\n";
		$this->MultiCell($width, 10, $val, 1, 'L');
	}
}

$pdf = new MYPDF('P', 'mm', 'A4', true, 'UTF-8', false);
$pdf->setMargins(10, 10, 10);
$pdf->setCellMargins(10, 0, 10, 0);
$pdf->setAutoPageBreak(false);
$pdf->setFont('helvetica', '', 12);
$pdf->AddPage();
$pdf->crash();
$pdf->Output('file.pdf', 'I');

```