### PR TITLE
Fixed: null check on Output($name) for PHP 8.1

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7632,7 +7632,7 @@ class TCPDF {
 			$dest = $dest ? 'D' : 'F';
 		}
 		$dest = strtoupper($dest);
-		if ($dest[0] != 'F') {
+		if ($dest[0] != 'F' && $name !== null) {
 			$name = preg_replace('/[\s]+/', '_', $name);
 			$name = preg_replace('/[^a-zA-Z0-9_\.-]/', '', $name);
 		}


### PR DESCRIPTION
Fixes PHP 8.1 deprecation warning in case null value given for Output:
```preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated```