### PR TITLE
[FIX] PDF417 produces corrupt output #488

### DIFF
--- a/include/barcodes/pdf417.php
+++ b/include/barcodes/pdf417.php
@@ -943,8 +943,8 @@ class PDF417 {
 						// tmp array for the 6 bytes block
 						$cw6 = array();
 						do {
-							$d = bcmod($t, '900');
-							$t = bcdiv($t, '900');
+							$d = bcmod($t, '900', 0);
+							$t = bcdiv($t, '900', 0);
 							// prepend the value to the beginning of the array
 							array_unshift($cw6, $d);
 						} while ($t != '0');
@@ -969,8 +969,8 @@ class PDF417 {
 					}
 					$t = '1'.$code;
 					do {
-						$d = bcmod($t, '900');
-						$t = bcdiv($t, '900');
+						$d = bcmod($t, '900', 0);
+						$t = bcdiv($t, '900', 0);
 						array_unshift($cw, $d);
 					} while ($t != '0');
 					$code = $rest;


### PR DESCRIPTION
[FIX] PDF417 produces corrupt output [https://github.com/tecnickcom/TCPDF/issues/488](url)