### PR TITLE
Undefined offset error in writeHTML() when last DOM element has display:none

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -17359,6 +17359,7 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 					++$key;
 				}
 			}
+			if ($key == $maxel) break;
 			if ($dom[$key]['tag'] AND isset($dom[$key]['attribute']['pagebreak'])) {
 				// check for pagebreak
 				if (($dom[$key]['attribute']['pagebreak'] == 'true') OR ($dom[$key]['attribute']['pagebreak'] == 'left') OR ($dom[$key]['attribute']['pagebreak'] == 'right')) {


### PR DESCRIPTION
When inserting HTML into the PDF using `writeHTML()`, if an element in the DOM has style "display:none" and there are no other elements after it, undefined offset errors occur.

Simple test script:

```php
<?php
require_once('tcpdf/tcpdf.php');
$pdf = new TCPDF();
$pdf->AddPage();
$html = '<p style="display:none">Foobar</p>';
$pdf->writeHTML($html);
$pdf->Output('/tmp/test.pdf', 'F');
exit;
?>
```

Expected behaviour: no errors.

Actual behaviour:

```
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 17362
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 17376
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 17427
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 17479
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 17687
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 18145
PHP Notice:  Undefined offset: 4 in /home/indrek/tcpdf/tcpdf.php on line 18435
```