### PR TITLE
Update qrcode.php

### DIFF
--- a/include/barcodes/qrcode.php
+++ b/include/barcodes/qrcode.php
@@ -888,11 +888,11 @@ class QRcode {
 			if ($col >= $this->rsblocks[0]['dataLength']) {
 				$row += $this->b1;
 			}
-			$ret = $this->rsblocks[$row]['data'][$col];
+			$ret = $this->rsblocks[$row]['data'][(int)$col];
 		} elseif ($this->count < $this->dataLength + $this->eccLength) {
 			$row = ($this->count - $this->dataLength) % $this->blocks;
 			$col = ($this->count - $this->dataLength) / $this->blocks;
-			$ret = $this->rsblocks[$row]['ecc'][$col];
+			$ret = $this->rsblocks[$row]['ecc'][(int)$col];
 		} else {
 			return 0;
 		}


### PR DESCRIPTION
Deprecation warning PHP 8.1
Deprecated (8192): Implicit conversion from float 4.833333333333333 to int loses precision