### PR TITLE
Support Apache 2.4 directives in .htaccess file

### DIFF
--- a/tools/.htaccess
+++ b/tools/.htaccess
@@ -1,1 +1,10 @@
-deny from all
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+</IfModule>


### PR DESCRIPTION
Update the .htaccess files to support Apache 2.4 directives with backwards compatibility for Apache 2.2.

See: https://httpd.apache.org/docs/2.4/upgrading.html#run-time