### PR TITLE
Remove examples from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.gitattributes export-ignore
-/examples export-ignore
 /tests export-ignore
 /scripts export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.gitattributes export-ignore
+/examples export-ignore
 /tests export-ignore
 /scripts export-ignore

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,10 @@
             "include/barcodes/pdf417.php",
             "include/barcodes/qrcode.php"
         ]
+    },
+    "archive": {
+        "exclude": [
+            "/examples"
+        ]
     }
 }


### PR DESCRIPTION
Examples are embed in dist packages fetched from packagist. In such context, I guess they are not really usefull. Removing them will reduce the package weight from 1.8MB. As package is installed about 35 000 times a day, it will save lots of network trafic and disk space.