### PR TITLE
Fix for PHP 8.1

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -4283,7 +4283,7 @@ class TCPDF {
 			// all fonts must be embedded
 			$family = 'pdfa'.$family;
 		}
-		$tempstyle = strtoupper($style ?? '');
+		$tempstyle = strtoupper($style === null ? '' : $style);
 		$style = '';
 		// underline
 		if (strpos($tempstyle, 'U') !== false) {

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -4283,7 +4283,7 @@ class TCPDF {
 			// all fonts must be embedded
 			$family = 'pdfa'.$family;
 		}
-		$tempstyle = strtoupper($style);
+		$tempstyle = strtoupper($style ?? '');
 		$style = '';
 		// underline
 		if (strpos($tempstyle, 'U') !== false) {


### PR DESCRIPTION
If $style is empty, PHP is throwing a warning.You need to set the default as empty string if $style is not set.