### PR TITLE
Avoid a deprecated error from PHP8.1

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -286,7 +286,7 @@ class TCPDF_STATIC {
 	 */
 	public static function _escapeXML($str) {
 		$replaceTable = array("\0" => '', '&' => '&amp;', '<' => '&lt;', '>' => '&gt;');
-		$str = strtr($str, $replaceTable);
+		$str = strtr(strval($str), $replaceTable);
 		return $str;
 	}
 

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -286,7 +286,7 @@ class TCPDF_STATIC {
 	 */
 	public static function _escapeXML($str) {
 		$replaceTable = array("\0" => '', '&' => '&amp;', '<' => '&lt;', '>' => '&gt;');
-		$str = strtr(strval($str), $replaceTable);
+		$str = strtr($str === null ? '' : $str, $replaceTable);
 		return $str;
 	}
 


### PR DESCRIPTION
Error "strtr(): Passing null to parameter #1 ($string) of type string is deprecated" avoided by converting value to a string.