### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/include/barcodes/qrcode.php
+++ b/include/barcodes/qrcode.php
@@ -638,7 +638,8 @@ class QRcode {
 		$barcode_array['bcode'] = array();
 		foreach ($qrTab as $line) {
 			$arrAdd = array();
-			foreach (str_split($line) as $char) {
+            $chars = function_exists('mb_str_split') ? mb_str_split($line) : str_split($line);
+			foreach ($chars as $char) {
 				$arrAdd[] = ($char=='1')?1:0;
 			}
 			$barcode_array['bcode'][] = $arrAdd;
@@ -1307,7 +1308,8 @@ class QRcode {
 				return $this->eatAn();
 			}
 		}
-		$this->items = $this->appendNewInputItem($this->items, QR_MODE_NM, $run, str_split($this->dataStr));
+        $data = function_exists('mb_str_split') ? mb_str_split($this->dataStr) : str_split($this->dataStr);
+		$this->items = $this->appendNewInputItem($this->items, QR_MODE_NM, $run, $data);
 		return $run;
 	}
 
@@ -1346,7 +1348,8 @@ class QRcode {
 				return $this->eat8();
 			}
 		}
-		$this->items = $this->appendNewInputItem($this->items, QR_MODE_AN, $run, str_split($this->dataStr));
+        $data = function_exists('mb_str_split') ? mb_str_split($this->dataStr) : str_split($this->dataStr);
+		$this->items = $this->appendNewInputItem($this->items, QR_MODE_AN, $run, $data);
 		return $run;
 	}
 
@@ -1359,7 +1362,8 @@ class QRcode {
 		while($this->identifyMode($p) == QR_MODE_KJ) {
 			$p += 2;
 		}
-		$this->items = $this->appendNewInputItem($this->items, QR_MODE_KJ, $p, str_split($this->dataStr));
+        $data = function_exists('mb_str_split') ? mb_str_split($this->dataStr) : str_split($this->dataStr);
+		$this->items = $this->appendNewInputItem($this->items, QR_MODE_KJ, $p, $data);
 		$run = $p;
 		return $run;
 	}
@@ -1409,7 +1413,8 @@ class QRcode {
 			}
 		}
 		$run = $p;
-		$this->items = $this->appendNewInputItem($this->items, QR_MODE_8B, $run, str_split($this->dataStr));
+        $data = function_exists('mb_str_split') ? mb_str_split($this->dataStr) : str_split($this->dataStr);
+		$this->items = $this->appendNewInputItem($this->items, QR_MODE_8B, $run, $data);
 		return $run;
 	}
 

--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -2004,7 +2004,7 @@ class TCPDF_FONTS {
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
 			$carr = array_map(array('TCPDF_FONTS', 'uniord'), $chars);
 		} else {
-			$chars = str_split($str);
+            $chars = function_exists('mb_str_split') ? mb_str_split($str) : str_split($str);
 			$carr = array_map('ord', $chars);
 		}
 		if (is_array($currentfont['subsetchars']) && is_array($carr)) {

--- a/tcpdf_barcodes_1d.php
+++ b/tcpdf_barcodes_1d.php
@@ -2179,8 +2179,8 @@ class TCPDFBarcode {
 		if (!preg_match('/^[fadtFADT]{65}$/', $code) == 1) {
 			return false;
 		}
-		$characters = str_split(strtolower($code), 1);
-		// build bars
+        $characters = function_exists('mb_str_split') ? mb_str_split(strtolower($code), 1) : str_split(strtolower($code), 1);
+        // build bars
 		$k = 0;
 		$bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 3, 'bcode' => array());
 		for ($i = 0; $i < 65; ++$i) {

--- a/tcpdf_barcodes_2d.php
+++ b/tcpdf_barcodes_2d.php
@@ -320,8 +320,8 @@ class TCPDF2DBarcode {
 				$this->barcode_array['num_cols'] = strlen($rows[0]);
 				$this->barcode_array['bcode'] = array();
 				foreach ($rows as $r) {
-					$this->barcode_array['bcode'][] = str_split($r, 1);
-				}
+                    $this->barcode_array['bcode'][] = function_exists('mb_str_split') ? mb_str_split($r, 1) : str_split($r, 1);
+                }
 				$this->barcode_array['code'] = $code;
 				break;
 			}


### PR DESCRIPTION
In PHP 8.2, the str_split function will returns empty arrays for empty strings.
See: https://php.watch/versions/8.2/str_split-empty-string-empty-array

We can use mb_str_split() instead