### PR TITLE
 Fix SPDX license ID

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "homepage": "http://www.tcpdf.org/",
     "version": "6.6.2",
-    "license": "LGPL-3.0-only",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "Nicola Asuni",


### PR DESCRIPTION
As LICENSE.TXT states:  

> either version 3 of the License, or (at your option) any later version.