### PR TITLE
show correct error on incorrect encoding

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -2002,7 +2002,11 @@ class TCPDF_FONTS {
 		if ($isunicode) {
 			// requires PCRE unicode support turned on
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
-			$carr = array_map(array('TCPDF_FONTS', 'uniord'), $chars);
+			if(empty($chars)){
+				die('TCPDF Error: Incorrect encoding: '.$str);
+			}else{
+				$carr = array_map(array('TCPDF_FONTS', 'uniord'), $chars);
+			}
 		} else {
 			$chars = str_split($str);
 			$carr = array_map('ord', $chars);


### PR DESCRIPTION
Signed-off-by: Ruben Barkow-Kuder <github@r.z11.de>


E.G if you try this:

    $pdf->multiCell(0, 4, 'Some non-UTF-8 text: '.unhtmlentities('&uuml;'), 0, 'L');

You will get this error on PHP 8.1:

    Fatal error: Uncaught ValueError: max(): Argument #1 ($value) must contain at least one element in tcpdf.php:6412

This commit will show a useful error with the causing string