### PR TITLE
Fix PHP Warning: chr() expects parameter 1 to be int, string given

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1671,7 +1671,11 @@ class TCPDF_FONTS {
 			return chr($c);
 		} elseif ($c <= 0x7F) {
 			// one byte
-			return chr($c);
+			if (is_int($c)) {
+				return chr($c);
+			} else {
+				return chr(intval($c));
+			}
 		} elseif ($c <= 0x7FF) {
 			// two bytes
 			return chr(0xC0 | $c >> 6).chr(0x80 | $c & 0x3F);


### PR DESCRIPTION
in include/tcpdf_fonts.php on line 1674