### PR TITLE
Typehints for getHeaderMargin() and setHeaderMargin() are inconsistent

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -574,12 +574,14 @@ class TCPDF {
 	/**
 	 * Minimum distance between header and top page margin.
 	 * @protected
+	 * @var float
 	 */
 	protected $header_margin;
 
 	/**
 	 * Minimum distance between footer and bottom page margin.
 	 * @protected
+	 * @var float
 	 */
 	protected $footer_margin;
 

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -3372,7 +3372,7 @@ class TCPDF {
 	/**
 	 * Set header margin.
 	 * (minimum distance between header and top page margin)
-	 * @param int $hm distance in user units
+	 * @param float $hm distance in user units
 	 * @public
 	 */
 	public function setHeaderMargin($hm=10) {
@@ -3392,7 +3392,7 @@ class TCPDF {
 	/**
 	 * Set footer margin.
 	 * (minimum distance between footer and bottom page margin)
-	 * @param int $fm distance in user units
+	 * @param float $fm distance in user units
 	 * @public
 	 */
 	public function setFooterMargin($fm=10) {


### PR DESCRIPTION
This PR just updates a couple of inconsistent type-hints in the phpdoc.

The header/footer margins are both `float`, but the getters/setters have  inconsistent PHPDOC.

`getFooterMargin()` has `@return float`, but `setFooterMargin()` has `@param int $fm`.

`getHeaderMargin()` has `@return float`, but `setHeaderMargin()` has `@param int $hm`.

