### PR TITLE
Fixed problems with S25 barcode

### DIFF
--- a/tcpdf_barcodes_1d.php
+++ b/tcpdf_barcodes_1d.php
@@ -828,7 +828,7 @@ class TCPDFBarcode {
 		$chr['5'] = '11101011101010';
 		$chr['6'] = '10111011101010';
 		$chr['7'] = '10101011101110';
-		$chr['8'] = '10101110111010';
+		$chr['8'] = '11101010111010';
 		$chr['9'] = '10111010111010';
 		if ($checksum) {
 			// add checksum
@@ -838,7 +838,7 @@ class TCPDFBarcode {
 			// add leading zero if code-length is odd
 			$code = '0'.$code;
 		}
-		$seq = '11011010';
+		$seq = '1110111010';
 		$clen = strlen($code);
 		for ($i = 0; $i < $clen; ++$i) {
 			$digit = $code[$i];
@@ -848,7 +848,7 @@ class TCPDFBarcode {
 			}
 			$seq .= $chr[$digit];
 		}
-		$seq .= '1101011';
+		$seq .= '111010111';
 		$bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
 		return $this->binseq_to_array($seq, $bararray);
 	}


### PR DESCRIPTION
Using your S25 barcode generator I found a problem. The representation of the digit 8 was the same as 0. I fixed it. Now it is recognized correctly.

Additionally you were using different bar widths for the start and stop values. I changed this too.

One thing I did not change till now is the part where you add an leading 0 if the string is odd. Why do you do so? I can't find anything that S25 has to be even. Maybe you mixed it up with interleaved 2 of 5 bar code where you need the even number because the digits are represented from pairs of bars and whitespaces?