### PR TITLE
Fix of Deprecation warning with php 8.1 #614

### DIFF
--- a/include/barcodes/qrcode.php
+++ b/include/barcodes/qrcode.php
@@ -888,7 +888,7 @@ class QRcode {
 			if ($col >= $this->rsblocks[0]['dataLength']) {
 				$row += $this->b1;
 			}
-			$row =(int) $row;
+			$row = (int) $row;
 			$ret = $this->rsblocks[$row]['data'][$col];
 		} elseif ($this->count < $this->dataLength + $this->eccLength) {
 			$row = ($this->count - $this->dataLength) % $this->blocks;

--- a/include/barcodes/qrcode.php
+++ b/include/barcodes/qrcode.php
@@ -888,6 +888,7 @@ class QRcode {
 			if ($col >= $this->rsblocks[0]['dataLength']) {
 				$row += $this->b1;
 			}
+			$row =(int) $row;
 			$ret = $this->rsblocks[$row]['data'][$col];
 		} elseif ($this->count < $this->dataLength + $this->eccLength) {
 			$row = ($this->count - $this->dataLength) % $this->blocks;


### PR DESCRIPTION
Fix of Deprecation warning with php 8.1 #614

Array key was expecting integer but float was being passed. Typecasting to int should fix this issue 