### PR TITLE
Fix non-numeric value warning

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -5467,6 +5467,9 @@ class TCPDF {
 				$s .= 'q '.$this->TextColor.' ';
 			}
 			// rendering mode
+			if(!is_numeric($this->textstrokewidth)){
+ 				$this->textstrokewidth = 0;
+			}
 			$s .= sprintf('BT %d Tr %F w ET ', $this->textrendermode, ($this->textstrokewidth * $this->k));
 			// count number of spaces
 			$ns = substr_count($txt, chr(32));


### PR DESCRIPTION
Fixes this warning on generating PDF:
Warning: A non-numeric value encountered in /tcpdf/tcpdf.php on line 5473