### PR TITLE
Fixes for PHP 8.2 in tcpdf_fonts.php - fixes #632

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1780,9 +1780,9 @@ class TCPDF_FONTS {
 	 */
 	public static function UTF8ArrayToUniArray($ta, $isunicode=true) {
 		if ($isunicode) {
-			return array_map(self::class . "::unichrUnicode",$ta);
+			return array_map(array('self','unichrUnicode'),$ta);
 		}
-		return array_map(self::class . "::unichrASCII",$ta);
+		return array_map(array('self','unichrUnicode'),$ta);
 	}
 
 	/**
@@ -2002,7 +2002,7 @@ class TCPDF_FONTS {
 		if ($isunicode) {
 			// requires PCRE unicode support turned on
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
-			$carr = array_map(self::class . "::uniord",$chars);
+			$carr = array_map(array('self','uniord'),$chars);
 		} else {
 			$chars = str_split($str);
 			$carr = array_map('ord', $chars);

--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1780,9 +1780,9 @@ class TCPDF_FONTS {
 	 */
 	public static function UTF8ArrayToUniArray($ta, $isunicode=true) {
 		if ($isunicode) {
-			return array_map(array('self','unichrUnicode'),$ta);
+			return array_map(array('self','unichrUnicode'), $ta);
 		}
-		return array_map(array('self','unichrUnicode'),$ta);
+		return array_map(array('self','unichrUnicode'), $ta);
 	}
 
 	/**
@@ -2002,7 +2002,7 @@ class TCPDF_FONTS {
 		if ($isunicode) {
 			// requires PCRE unicode support turned on
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
-			$carr = array_map(array('self','uniord'),$chars);
+			$carr = array_map(array('self','uniord'), $chars);
 		} else {
 			$chars = str_split($str);
 			$carr = array_map('ord', $chars);

--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1780,9 +1780,9 @@ class TCPDF_FONTS {
 	 */
 	public static function UTF8ArrayToUniArray($ta, $isunicode=true) {
 		if ($isunicode) {
-			return array_map(array('TCPDF_FONTS', 'unichrUnicode'), $ta);
+			return array_map(self::class . "::unichrUnicode",$ta);
 		}
-		return array_map(array('TCPDF_FONTS', 'unichrASCII'), $ta);
+		return array_map(self::class . "::unichrASCII",$ta);
 	}
 
 	/**
@@ -2002,7 +2002,7 @@ class TCPDF_FONTS {
 		if ($isunicode) {
 			// requires PCRE unicode support turned on
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
-			$carr = array_map(array('TCPDF_FONTS', 'uniord'), $chars);
+			$carr = array_map(self::class . "::uniord",$chars);
 		} else {
 			$chars = str_split($str);
 			$carr = array_map('ord', $chars);

--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1780,9 +1780,9 @@ class TCPDF_FONTS {
 	 */
 	public static function UTF8ArrayToUniArray($ta, $isunicode=true) {
 		if ($isunicode) {
-			return array_map(array('self','unichrUnicode'), $ta);
+			return array_map(get_called_class().'::unichrUnicode', $ta);
 		}
-		return array_map(array('self','unichrUnicode'), $ta);
+		return array_map(get_called_class().'::unichrASCII', $ta);
 	}
 
 	/**
@@ -2002,7 +2002,7 @@ class TCPDF_FONTS {
 		if ($isunicode) {
 			// requires PCRE unicode support turned on
 			$chars = TCPDF_STATIC::pregSplit('//','u', $str, -1, PREG_SPLIT_NO_EMPTY);
-			$carr = array_map(array('self','uniord'), $chars);
+			$carr = array_map(get_called_class().'::uniord', $chars);
 		} else {
 			$chars = str_split($str);
 			$carr = array_map('ord', $chars);


### PR DESCRIPTION
Fixes "use of "self" in callables is deprecated" warning is arising from tcpdf_fonts.php when using PHP >= 8.2