### PR TITLE
ImageSVG() does not calculate the correct w/h values anymore - fix it

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23034,12 +23034,6 @@ class TCPDF {
 				}
 			}
 		}
-		if ($ow <= 0) {
-			$ow = 1;
-		}
-		if ($oh <= 0) {
-			$oh = 1;
-		}
 		// calculate image width and height on document
 		if (($w <= 0) AND ($h <= 0)) {
 			// convert image size to document unit


### PR DESCRIPTION
Fix for issue #660 Automatic calculation of w/h fails for ImageSVG()
The bug appeared in 6.0.031 and was caused by the
'avoid "division by zero"' part of commit: 0c26f23 The fix, for me, is to remove the div_by_zero mitigation.