### PR TITLE
fix: base64 images not rendered inside of html

### DIFF
--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -280,7 +280,7 @@
 	- Bug item #956 "Monospaced fonts are not alignd at the baseline" was fixed.
 	- Bug item #964 "Problem when changing font size" was fixed.
 	- Bug item #969 "ImageSVG with radialGradient problem" was fixed.
-	- sRGB.icc file was replaced with the one from the Debian package icc-profiles-free (2.0.1+dfsg-1) 
+	- sRGB.icc file was replaced with the one from the Debian package icc-profiles-free (2.0.1+dfsg-1)
 
 6.0.091 (2014-08-13)
 	- Issue #325"Division by zero when css fontsize equals 0" was fixed.
@@ -289,7 +289,7 @@
 	- Starting from this version TCPDF is also available in GitHub at https://github.com/tecnickcom/TCPDF
 	- Function getmypid() was removed for better compatibility with shared hosting environments.
 	- Support for pulling SVG stroke opacity value from RGBa color was mergeg [adf006].
-	- Bug item #951 "HTML Table within TCPDF columns doesnt flow correctly on page break ..." was fixed. 
+	- Bug item #951 "HTML Table within TCPDF columns doesnt flow correctly on page break ..." was fixed.
 
 6.0.089 (2014-07-16)
 	- Bug item #948 "bottom line of rowspan cell not work correctly" was fixed.

--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1876,6 +1876,9 @@ class TCPDF_STATIC {
 		if (preg_match('|^https?://|', $filename) == 1) {
 			return self::url_exists($filename);
 		}
+		if (stripos($filename, 'data:') === 0) {
+			return true;
+		}
 		if (strpos($filename, '://')) {
 			return false; // only support http and https wrappers for security reasons
 		}


### PR DESCRIPTION
I'm not sure when this happened, but default base64 encoded images were no longer rendered in html  text. 

If the image is rendered like this:
```
<img src="data:image/png;base64,....." />
```

the image was not rendered when inside of an html text. Instead one has to replace `data:image/png;base64,` with `@`which in my opinion is not ideal and an overhead. 

https://github.com/tecnickcom/TCPDF/issues/179