### PR TITLE
Fix PHP8.2 deprecated warnings in getHtmlDomArray() in tcpdf.php

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16389,6 +16389,8 @@ class TCPDF {
 	 * @since 3.2.000 (2008-06-20)
 	 */
 	protected function getHtmlDomArray($html) {
+		if(empty($html))
+			return [];
 		// array of CSS styles ( selector => properties).
 		$css = array();
 		// get CSS array defined at previous call

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16390,7 +16390,7 @@ class TCPDF {
 	 */
 	protected function getHtmlDomArray($html) {
 		if(empty($html))
-			return [];
+			return array(); 
 		// array of CSS styles ( selector => properties).
 		$css = array();
 		// get CSS array defined at previous call


### PR DESCRIPTION
In the event that the $html variable is either null or has any falsy value, we promptly return an empty array. This optimization not only ensures that we avoid executing the entire function but also addresses the E_DEPRECATED warning associated with passing null to the preg_match_all function, contributing to improved performance and code stability.

Fixes #670