### PR TITLE
Fixed handling of transparency in PDF/A mode in addExtGState method

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -13936,8 +13936,8 @@ class TCPDF {
 	 * @since 3.0.000 (2008-03-27)
 	 */
 	protected function addExtGState($parms) {
-		if ($this->pdfa_mode || $this->pdfa_version >= 2) {
-			// transparencies are not allowed in PDF/A mode
+		if (($this->pdfa_mode && $this->pdfa_version < 2) || ($this->state != 2)) {
+			// transparency is not allowed in PDF/A-1 mode
 			return;
 		}
 		// check if this ExtGState already exist


### PR DESCRIPTION
The condition allowed to add ExtGState in all PDF/A modes and disallowed it in default mode until now. This looks logically wrong.

This fix inlines the condition with setExtGState to allow transparency parameters for non-PDF/A and PDF/A > 1 documents.

The state condition is copied from 'setExtGState'.