### PR TITLE
Update tcpdf.php - Allow to show "0"

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16440,7 +16440,7 @@ class TCPDF {
 			)
 		);
 
-		if(empty($html)) {
+		if(empty($html) && $html != '0') {
 			return $dom;
 		}
 		// array of CSS styles ( selector => properties).

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16440,7 +16440,7 @@ class TCPDF {
 			)
 		);
 
-		if(empty($html) && $html != '0') {
+		if($html === '' || $html === null) {
 			return $dom;
 		}
 		// array of CSS styles ( selector => properties).


### PR DESCRIPTION
Since the version 6.7.4, the "0" is considered like empty string and not displayed