### PR TITLE
improve SVG detection by checking for (mandatory) namespace and closi…

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -19055,7 +19055,7 @@ class TCPDF {
 				if ($imgsrc[0] === '@') {
 					// data stream
 					$imgsrc = '@'.base64_decode(substr($imgsrc, 1));
-					$type = preg_match('/<svg([^\>]*)>/si', $imgsrc) ? 'svg' : '';
+					$type = preg_match('/<svg\s+[^>]*\bxmlns\s*=\s*"http:\/\/www\.w3\.org\/2000\/svg"[^>]*>.*<\/svg>/is', $imgsrc) ? 'svg' : '';
 				} else if (preg_match('@^data:image/([^;]*);base64,(.*)@', $imgsrc, $reg)) {
 					$imgsrc = '@'.base64_decode($reg[2]);
 					$type = $reg[1];

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -19055,7 +19055,7 @@ class TCPDF {
 				if ($imgsrc[0] === '@') {
 					// data stream
 					$imgsrc = '@'.base64_decode(substr($imgsrc, 1));
-					$type = preg_match('/<svg\s+[^>]*\bxmlns\s*=\s*"http:\/\/www\.w3\.org\/2000\/svg"[^>]*>.*<\/svg>/is', $imgsrc) ? 'svg' : '';
+					$type = preg_match('/<svg\s+[^>]*[^>]*>.*<\/svg>/is', $imgsrc) ? 'svg' : '';
 				} else if (preg_match('@^data:image/([^;]*);base64,(.*)@', $imgsrc, $reg)) {
 					$imgsrc = '@'.base64_decode($reg[2]);
 					$type = $reg[1];


### PR DESCRIPTION
This expands the regex used to detect SVGs by checking for the existence of the (mandatory) namespace attribute (`xmlns= http //www.w3.org/2000/svg`) and the closing `</svg>` tag.
