### PR TITLE
Fixed image link for named internal destination

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -19124,7 +19124,7 @@ class TCPDF {
 				$imglink = '';
 				if (isset($this->HREF['url']) AND !TCPDF_STATIC::empty_string($this->HREF['url'])) {
 					$imglink = $this->HREF['url'];
-					if ($imglink[0] == '#') {
+					if ($imglink[0] == '#' AND is_numeric($imglink[1])) {
 						// convert url to internal link
 						$lnkdata = explode(',', $imglink);
 						if (isset($lnkdata[0])) {


### PR DESCRIPTION
This PR ensures that image link is converted only when it is really needed. This is FIX #770 