### PR TITLE
Refactor array search logic for support php 8.4.

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -5562,7 +5562,9 @@ class TCPDF {
 						// x space to skip
 						if ($spacewidth != 0) {
 							// justification shift
-							$xshift += (count(array_keys($uniarr, 32)) * $spw);
+							$xshift += (count(array_keys(array_filter($uniarr, function ($element) {
+                                return $element == 32;
+                            }))) * $spw);
 						}
 						$xshift += $this->GetArrStringWidth($uniarr); // + shift justification
 					} else {

--- a/tcpdf_barcodes_1d.php
+++ b/tcpdf_barcodes_1d.php
@@ -543,7 +543,9 @@ class TCPDFBarcode {
 		$sum = 0;
 		$clen = strlen($code);
 		for ($i = 0 ; $i < $clen; ++$i) {
-			$k = array_keys($chars, $code[$i]);
+			$k = array_keys(array_filter($chars, function ($value) use ($code, $i) {
+                return $value == $code[$i];
+            }));
 			$sum += $k[0];
 		}
 		$j = ($sum % 43);
@@ -699,7 +701,9 @@ class TCPDFBarcode {
 		$p = 1;
 		$check = 0;
 		for ($i = ($len - 1); $i >= 0; --$i) {
-			$k = array_keys($chars, $code[$i]);
+            $k = array_keys(array_filter($chars, function ($value) use ($code, $i) {
+                return $value == $code[$i];
+            }));
 			$check += ($k[0] * $p);
 			++$p;
 			if ($p > 20) {
@@ -713,7 +717,9 @@ class TCPDFBarcode {
 		$p = 1;
 		$check = 0;
 		for ($i = $len; $i >= 0; --$i) {
-			$k = array_keys($chars, $code[$i]);
+            $k = array_keys(array_filter($chars, function ($value) use ($code, $i) {
+                return $value == $code[$i];
+            }));
 			$check += ($k[0] * $p);
 			++$p;
 			if ($p > 15) {
@@ -1760,9 +1766,8 @@ class TCPDFBarcode {
 			}
 			$row %= 6;
 			$col %= 6;
-			$chk = array_keys($checktable, array($row,$col));
-			$code .= $chk[0];
-			++$len;
+            $code .= array_search(array($row, $col), $checktable);
+            ++$len;
 		}
 		$k = 0;
 		if ($notkix) {


### PR DESCRIPTION
Related to #662 
Replaces direct `array_keys` usage with `array_filter` and closures for more explicit condition checks. Simplifies a specific case using `array_search` to enhance code clarity and maintainability. No functional changes introduced.