### PR TITLE
Automatically add destinations from HTML code

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -17427,6 +17427,9 @@ class TCPDF {
 				}
 			}
 			if ($key == $maxel) break;
+			if ($dom[$key]['tag'] AND $dom[$key]['opening'] AND !empty($dom[$key]['attribute']['id'])) {
+				$this->setDestination($dom[$key]['attribute']['id']);
+			}
 			if ($dom[$key]['tag'] AND isset($dom[$key]['attribute']['pagebreak'])) {
 				// check for pagebreak
 				if (($dom[$key]['attribute']['pagebreak'] == 'true') OR ($dom[$key]['attribute']['pagebreak'] == 'left') OR ($dom[$key]['attribute']['pagebreak'] == 'right')) {


### PR DESCRIPTION
This PR will automatically sets the destinations based on HTML id attributes.

This will allow hash links to work as expected (as in the web browser). see: FIX #803