### PR TITLE
Wrong default value when $table_el['old_cell_padding'] is missing

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -20012,7 +20012,7 @@ class TCPDF {
 					}
 				}
 				if (!$in_table_head) { // we are not inside a thead section
-					$this->cell_padding = isset($table_el['old_cell_padding']) ? $table_el['old_cell_padding'] : null;
+					$this->cell_padding = isset($table_el['old_cell_padding']) ? $table_el['old_cell_padding'] : array('T' => 0, 'R' => 0, 'B' => 0, 'L' => 0);
 					// reset row height
 					$this->resetLastH();
 					if (($this->page == ($this->numpages - 1)) AND ($this->pageopen[$this->numpages])) {


### PR DESCRIPTION
Fix for https://github.com/tecnickcom/TCPDF/issues/806
