### PR TITLE
Fixed PHP warning when empty hash link for image exists in HTML

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -19151,7 +19151,7 @@ class TCPDF {
 				$imglink = '';
 				if (isset($this->HREF['url']) AND !TCPDF_STATIC::empty_string($this->HREF['url'])) {
 					$imglink = $this->HREF['url'];
-					if ($imglink[0] == '#' AND is_numeric($imglink[1])) {
+					if ($imglink[0] == '#' AND isset($imglink[1]) AND is_numeric($imglink[1])) {
 						// convert url to internal link
 						$lnkdata = explode(',', $imglink);
 						if (isset($lnkdata[0])) {


### PR DESCRIPTION
This PR fix warning when empty hash link for image is defined HTML.  FIX #794 
Example code is in #794
