### PR TITLE
Fix for application of alpha component to SVG RGBA fills

### DIFF
--- a/include/tcpdf_colors.php
+++ b/include/tcpdf_colors.php
@@ -275,7 +275,7 @@ class TCPDF_COLORS {
 		$color = strtolower($color);
 		// check for javascript color array syntax
 		if (strpos($color, '[') !== false) {
-			if (preg_match('/[\[][\"\'](t|g|rgb|cmyk)[\"\'][\,]?([0-9\.]*+)[\,]?([0-9\.]*+)[\,]?([0-9\.]*+)[\,]?([0-9\.]*+)[\]]/', $color, $m) > 0) {
+			if (preg_match('/[\[][\"\'](t|g|rgba|rgb|cmyk)[\"\'][\,]?([0-9\.]*+)[\,]?([0-9\.]*+)[\,]?([0-9\.]*+)[\,]?([0-9\.]*+)[\]]/', $color, $m) > 0) {
 				$returncolor = array();
 				switch ($m[1]) {
 					case 'cmyk': {
@@ -286,7 +286,8 @@ class TCPDF_COLORS {
 						$returncolor['K'] = max(0, min(100, (floatval($m[5]) * 100)));
 						break;
 					}
-					case 'rgb': {
+					case 'rgb':
+					case 'rgba': {
 						// RGB
 						$returncolor['R'] = max(0, min(255, (floatval($m[2]) * 255)));
 						$returncolor['G'] = max(0, min(255, (floatval($m[3]) * 255)));
@@ -316,6 +317,25 @@ class TCPDF_COLORS {
 		}
 		if (strlen($color) == 0) {
 			return $defcol;
+		}
+		// RGBA ARRAY
+		if (substr($color, 0, 4) == 'rgba') {
+			$codes = substr($color, 5);
+			$codes = str_replace(')', '', $codes);
+			$returncolor = explode(',', $codes);
+			// remove alpha component
+			array_pop($returncolor);
+			foreach ($returncolor as $key => $val) {
+				if (strpos($val, '%') > 0) {
+					// percentage
+					$returncolor[$key] = (255 * intval($val) / 100);
+				} else {
+					$returncolor[$key] = intval($val); /* floatize */
+				}
+				// normalize value
+				$returncolor[$key] = max(0, min(255, $returncolor[$key]));
+			}
+			return $returncolor;
 		}
 		// RGB ARRAY
 		if (substr($color, 0, 3) == 'rgb') {

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23479,6 +23479,8 @@ class TCPDF {
 			$fill_color = TCPDF_COLORS::convertHTMLColorToDec($svgstyle['fill'], $this->spot_colors);
 			if ($svgstyle['fill-opacity'] != 1) {
 				$this->setAlpha($this->alpha['CA'], 'Normal', $svgstyle['fill-opacity'], false);
+			} elseif (preg_match('/rgba\(\d+%?,\s*\d+%?,\s*\d+%?,\s*(\d+(?:\.\d+)?)\)/i', $svgstyle['fill'], $rgba_matches)) {
+				$this->setAlpha($this->alpha['CA'], 'Normal', $rgba_matches[1], false);
 			}
 			$this->setFillColorArray($fill_color);
 			if ($svgstyle['fill-rule'] == 'evenodd') {


### PR DESCRIPTION
RGBA fills are incorrectly handled resulting in a 4 component array that ends up applied as a CMYK color.

This PR correctly converts the RGBA color to a 3 component (RGB) array. It also extracts the alpha component from the RGBA fill and applies it to the PDF objects CA component. 