### PR TITLE
Preserving percentage gradient decimals and correctly clamp coordinates

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23500,7 +23500,8 @@ class TCPDF {
 				$gradient['coords'][4] /= $w;
 			} elseif ($gradient['mode'] == 'percentage') {
 				foreach($gradient['coords'] as $key => $val) {
-					$gradient['coords'][$key] = (intval($val) / 100);
+					$val = floatval($val) / 100;
+					$gradient['coords'][$key] = $val;
 					if ($val < 0) {
 						$gradient['coords'][$key] = 0;
 					} elseif ($val > 1) {


### PR DESCRIPTION
Percentage based gradient coordinates are rounded to integers, instead of floats, before conversion to a ratio. The subsequent clamping operation is then performed against the original value in $val instead of the result of ratio conversion.

This PR preserves the decimals of the percentage coordinates and correctly clamps against the updated result.

Angled gradient output is therefore much improved for SVG's such as below.

```
<svg xmlns="http://www.w3.org/2000/svg" width="500" height="660" viewBox="0 0 500 660">
	<defs>
		<linearGradient id="foregroundGradient5379" x1="14.64465%" y1="85.35535%" x2="85.35535%" y2="14.64465%">
			<stop offset="0%" stop-color="#FFFFFF" /><stop offset="100%" stop-color="#FF0000" />
		</linearGradient>
	</defs>
	<path  fill="url(#foregroundGradient5379)" d="M 0 50 C 0 22.3858, 22.3858 0, 50 0 L 500 0 L 500 610 C 472.3859 610.0001, 449.9999 632.3858, 450 660 L 0 660 Z" />
</svg>
```

