### PR TITLE
Fix image on footer problems

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -6925,8 +6925,8 @@ class TCPDF {
 			// fallback to avoid division by zero
 			$h = $h == 0 ? 1 : $h;
 			$ratio_wh = ($w / $h);
-			if (($y + $h) > $this->PageBreakTrigger) {
-				$h = $this->PageBreakTrigger - $y;
+			if (($y + $h) > $this->PageBreakTrigger + $this->bMargin) {
+				$h = $this->PageBreakTrigger + $this->bMargin - $y;
 				$w = ($h * $ratio_wh);
 			}
 			if ((!$this->rtl) AND (($x + $w) > ($this->w - $this->rMargin))) {


### PR DESCRIPTION
If you put images on footer, when you create multiple pages pdf, in all pages but last, the images are often printed rotated and with wrong dimensions.
This is because we have a PageBreakTrigger that involves the inner content, but we should avoid this operations on footer images that are not involved in page break and should by printed in the same way in first, inner and last pages.
I'm not completely sure that this fix has not side effects: I hope that the mantainer can review it.