### PR TITLE
Fix bad `text-align` from HTML source

### DIFF
--- a/examples/example_001.php
+++ b/examples/example_001.php
@@ -92,7 +92,7 @@ $html = <<<EOD
 <h1>Welcome to <a href="http://www.tcpdf.org" style="text-decoration:none;background-color:#CC0000;color:black;">&nbsp;<span style="color:black;">TC</span><span style="color:white;">PDF</span>&nbsp;</a>!</h1>
 <i>This is the first example of TCPDF library.</i>
 <p>This text is printed using the <i>writeHTMLCell()</i> method but you can also use: <i>Multicell(), writeHTML(), Write(), Cell() and Text()</i>.</p>
-<p>Please check the source code documentation and other examples for further information.</p>
+<p style="text-align: ;">Please check the source code documentation and other examples for further information.</p>
 <p style="color:#CC0000;">TO IMPROVE AND EXPAND TCPDF I NEED YOUR SUPPORT, PLEASE <a href="http://sourceforge.net/donate/index.php?group_id=128076">MAKE A DONATION!</a></p>
 EOD;
 

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -16918,7 +16918,7 @@ class TCPDF {
 							$dom[$key]['height'] = $dom[$key]['style']['height'];
 						}
 						// check for text alignment
-						if (isset($dom[$key]['style']['text-align'])) {
+						if (isset($dom[$key]['style']['text-align'][0])) {
 							$dom[$key]['align'] = strtoupper($dom[$key]['style']['text-align'][0]);
 						}
 						// check for CSS border properties


### PR DESCRIPTION
In case the `text-align` attribute is badly defined in the HTML, PHP raise an error: `Warning: Uninitialized string offset 0`

<img width="1842" height="916" alt="image" src="https://github.com/user-attachments/assets/84ce721d-b8fc-4c32-bc30-7edfc23392e2" />
