### PR TITLE
Fix PHP 8.5 deprecation for xml_parser_free

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -23268,8 +23268,11 @@ class TCPDF {
 			$error_message = sprintf('SVG Error: %s at line %d', xml_error_string(xml_get_error_code($parser)), xml_get_current_line_number($parser));
 			$this->Error($error_message);
 		}
-		// free this XML parser
-		xml_parser_free($parser);
+		
+		// free this XML parser (does nothing in PHP >= 8.0)
+		if (function_exists('xml_parser_free') && PHP_VERSION_ID < 80000) {
+		    xml_parser_free($parser);
+		}
 
 		// >= PHP 7.0.0 "explicitly unset the reference to parser to avoid memory leaks"
 		unset($parser);


### PR DESCRIPTION
Add php version check to xml_parser_free() for PHP 8.5 compatibility.

From PHP 8.0 onwards, this function does nothing. PHP 8.5 adds a deprecation warning for this function usage, which should be prevented.