### PR TITLE
Fix PHP 8.5 deprecation on curl_close()

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1863,7 +1863,9 @@ class TCPDF_STATIC {
         curl_setopt_array($crs, $curlopts);
 		curl_exec($crs);
 		$code = curl_getinfo($crs, CURLINFO_HTTP_CODE);
-		curl_close($crs);
+		if (PHP_VERSION_ID < 80000) {
+			curl_close($crs);
+		}
 		return ($code == 200);
 	}
 
@@ -1995,7 +1997,9 @@ class TCPDF_STATIC {
 				$curlopts[CURLOPT_URL] = $url;
 				curl_setopt_array($crs, $curlopts);
 				$ret = curl_exec($crs);
-				curl_close($crs);
+				if (PHP_VERSION_ID < 80000) {
+					curl_close($crs);
+				}
 				if ($ret !== false) {
 					return $ret;
 				}


### PR DESCRIPTION
`curl_close()` is noop since 8.0.0 and emits `E_DEPRECATED` since 8.5.0.

This changes the code to call `curl_close()` only on PHP < 8.0.0.

* https://www.php.net/curl_close
* https://github.com/php/php-src/blob/php-8.0.0/UPGRADING#L1016-L1020
* https://github.com/php/php-src/blob/php-8.5.0/UPGRADING#L416-L418