### PR TITLE
Fix PHP 8.5 deprecation on null array offset

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7884,7 +7884,7 @@ class TCPDF {
 	 * @since 4.5.016 (2009-02-24)
 	 */
 	public function _destroy($destroyall=false, $preserve_objcopy=false) {
-		if (isset(self::$cleaned_ids[$this->file_id])) {
+		if (isset($this->file_id) && isset(self::$cleaned_ids[$this->file_id])) {
 			$destroyall = false;
 		}
 		if ($destroyall AND !$preserve_objcopy && isset($this->file_id)) {


### PR DESCRIPTION
Check file_id existence before array lookup, as using null array offset is [deprecated ](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset) starting php 8.5.