### PR TITLE
Fixed: Font subsetting - incorrect placement of head checksum

### DIFF
--- a/include/tcpdf_fonts.php
+++ b/include/tcpdf_fonts.php
@@ -1384,7 +1384,7 @@ class TCPDF_FONTS {
 		}
 		// set checkSumAdjustment on head table
 		$checkSumAdjustment = 0xB1B0AFBA - self::_getTTFtableChecksum($font, strlen($font));
-		$font = substr($font, 0, $table['head']['offset'] + $offset + 8).pack('N', $checkSumAdjustment).substr($font, $table['head']['offset'] + $offset + 12);
+		$font = substr($font, 0, $table['head']['offset'] + $offset + 4).pack('N', $checkSumAdjustment).substr($font, $table['head']['offset'] + $offset + 8);
 		return $font;
 	}
 


### PR DESCRIPTION
Currently, during font subsetting, head checksum is calculated and placed on offset 8 after head table start,
but this is incorrect and causes overwriting head.offset field!

The checksum should be placed in offset 4 after the tag 'head'.

This PR fixes this.

For me, this fixed PDF display error on Adobe Reader and or not diplaying proper characters in Edge PDF viewer.