### PR TITLE
Fix imagedestroy() deprecation in PHP 8.5

### DIFF
--- a/include/tcpdf_images.php
+++ b/include/tcpdf_images.php
@@ -126,7 +126,9 @@ class TCPDF_IMAGES {
 		// create temporary PNG image
 		imagepng($image, $tempfile);
 		// remove image from memory
-		imagedestroy($image);
+		if (PHP_VERSION_ID < 80000) {
+			imagedestroy($image);
+		}
 		// get PNG image data
 		$retvars = self::_parsepng($tempfile);
 		// tidy up by removing temporary image
@@ -145,7 +147,9 @@ class TCPDF_IMAGES {
 	 */
 	public static function _toJPEG($image, $quality, $tempfile) {
 		imagejpeg($image, $tempfile, $quality);
-		imagedestroy($image);
+		if (PHP_VERSION_ID < 80000) {
+			imagedestroy($image);
+		}
 		$retvars = self::_parsejpeg($tempfile);
 		// tidy up by removing temporary image
 		unlink($tempfile);

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -7437,12 +7437,16 @@ class TCPDF {
 					}
 				}
 				imagepng($imgalpha, $tempfile_alpha);
-				imagedestroy($imgalpha);
+				if (PHP_VERSION_ID < 80000) {
+					imagedestroy($imgalpha);
+				}
 				// extract image without alpha channel
 				$imgplain = imagecreatetruecolor($wpx, $hpx);
 				imagecopy($imgplain, $img, 0, 0, 0, 0, $wpx, $hpx);
 				imagepng($imgplain, $tempfile_plain);
-				imagedestroy($imgplain);
+				if (PHP_VERSION_ID < 80000) {
+					imagedestroy($imgplain);
+				}
 				$parsed = true;
 			} catch (Exception $e) {
 				// GD fails

--- a/tcpdf_barcodes_1d.php
+++ b/tcpdf_barcodes_1d.php
@@ -234,7 +234,9 @@ class TCPDFBarcode {
 			ob_start();
 			imagepng($png);
 			$imagedata = ob_get_clean();
-			imagedestroy($png);
+			if (PHP_VERSION_ID < 80000) {
+				imagedestroy($png);
+			}
 			return $imagedata;
 		}
 	}

--- a/tcpdf_barcodes_2d.php
+++ b/tcpdf_barcodes_2d.php
@@ -238,7 +238,9 @@ class TCPDF2DBarcode {
 			ob_start();
 			imagepng($png);
 			$imagedata = ob_get_clean();
-			imagedestroy($png);
+			if (PHP_VERSION_ID < 80000) {
+				imagedestroy($png);
+			}
 			return $imagedata;
 		}
 	}


### PR DESCRIPTION
`imagedestroy()` has been a no-op since PHP 8.0 and is formally deprecated in PHP 8.5, causing `E_DEPRECATED` warnings.

This wraps all 6 `imagedestroy()` calls with `if (PHP_VERSION_ID < 80000)` in:
- `tcpdf.php` (2 calls)
- `include/tcpdf_images.php` (2 calls)
- `tcpdf_barcodes_1d.php` (1 call)
- `tcpdf_barcodes_2d.php` (1 call)

Fixes: #843