### PR TITLE
Add configurable thousands separator for page number formatting

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -107,6 +107,12 @@ class TCPDF_STATIC {
 	public static $pageboxes = array('MediaBox', 'CropBox', 'BleedBox', 'TrimBox', 'ArtBox');
 
 	/**
+	 * String thousands separator
+	 * @private static
+	 */
+	private static $thousands_separator = '.';
+
+	/**
      * Array of default cURL options for curl_setopt_array.
      *
      * @var array<int, bool|int|string> cURL options.
@@ -1022,7 +1028,7 @@ class TCPDF_STATIC {
 	 * @public static
 	 */
 	public static function formatPageNumber($num) {
-		return number_format((float)$num, 0, '', '.');
+		return number_format((float)$num, 0, '', self::$thousands_separator);
 	}
 
 	/**
@@ -1035,7 +1041,7 @@ class TCPDF_STATIC {
 	 * @public static
 	 */
 	public static function formatTOCPageNumber($num) {
-		return number_format((float)$num, 0, '', '.');
+		return number_format((float)$num, 0, '', self::$thousands_separator);
 	}
 
 	/**
@@ -2654,6 +2660,16 @@ class TCPDF_STATIC {
 			}
 		}
 		return $page_mode;
+	}
+
+	/**
+	 * Set the thousands separator to use it in the number format.
+	 * @param string $separator
+	 * @return void
+	 * @public static
+	 */
+	public static function setThousandsSeparator($separator) {
+		self::$thousands_separator = $separator;
 	}
 
 } // END OF TCPDF_STATIC CLASS

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -3002,6 +3002,7 @@ class TCPDF {
 	 *
 	 * @param string $separator
 	 * @public
+	 * @return void
 	 */
 	public function setThousandsSeparator($separator) {
 		TCPDF_STATIC::setThousandsSeparator($separator);

--- a/tcpdf.php
+++ b/tcpdf.php
@@ -2997,6 +2997,16 @@ class TCPDF {
 		$this->allowLocalFiles = (bool) $allowLocalFiles;
 	}
 
+	/**
+	 * Set the thousands separator to use in the number formatting
+	 *
+	 * @param string $separator
+	 * @public
+	 */
+	public function setThousandsSeparator($separator) {
+		TCPDF_STATIC::setThousandsSeparator($separator);
+	}
+
 
 	/**
 	 * Throw an exception or print an error message and die if the K_TCPDF_PARSER_THROW_EXCEPTION_ERROR constant is set to true.


### PR DESCRIPTION
**This PR addresses the issue reported here:** https://github.com/tecnickcom/TCPDF/issues/861

## Overview
This pull request introduces the ability to configure the thousands separator used by `TCPDF_STATIC::formatPageNumber` and `TCPDF_STATIC::formatTOCPageNumber`.

Previously, these functions used a hard-coded dot (`.`) as the thousands separator, which caused issues for users in locales that use different conventions (comma, space, or no separator). This PR adds flexibility by allowing developers to set the separator at runtime.

## Background
The original implementation:
```php
public static function formatPageNumber($num) {
    return number_format((float)$num, 0, '', '.');
}

public static function formatTOCPageNumber($num) {
    return number_format((float)$num, 0, '', '.');
}
```
This forced all page numbers and TOC entries to use a dot separator regardless of locale. The enhancement makes the formatting customizable without modifying core files.

## What This PR Adds

- A new static property:
`TCPDF_STATIC::$thousands_separator`
- A setter method:
`TCPDF_STATIC::setThousandsSeparator($separator)`
- Updated logic in:
`TCPDF_STATIC::formatPageNumber`
`TCPDF_STATIC::formatTOCPageNumber`
to use the configurable separator.

## Benefits
- Proper internationalization/localization support
- No need to patch or fork TCPDF
- Backward-compatible (default separator remains `.`)
- Gives developers full control over number formatting in generated PDFs

## Example Usage
```php
$pdf = new TCPDF();

...
$pdf->setThousandsSeparator(',');
...
```

## Backward Compatibility
- Default behavior unchanged
- No API breakage
- Fully optional new feature

## Additional Notes
Happy to update the PR if maintainers prefer an alternative naming convention or a broader locale configuration approach.