### PR TITLE
fix: guard K_CURLOPTS constant to prevent fatal error when not defined

### DIFF
--- a/include/tcpdf_static.php
+++ b/include/tcpdf_static.php
@@ -1857,7 +1857,7 @@ class TCPDF_STATIC {
             $curlopts[CURLOPT_FOLLOWLOCATION] = true;
         }
         $curlopts = array_replace($curlopts, self::CURLOPT_DEFAULT);
-        $curlopts = array_replace($curlopts, K_CURLOPTS);
+        $curlopts = array_replace($curlopts, (defined('K_CURLOPTS') ? K_CURLOPTS : []));
         $curlopts = array_replace($curlopts, self::CURLOPT_FIXED);
         $curlopts[CURLOPT_URL] = $url;
         curl_setopt_array($crs, $curlopts);
@@ -1992,7 +1992,7 @@ class TCPDF_STATIC {
 					$curlopts[CURLOPT_FOLLOWLOCATION] = true;
 				}
 				$curlopts = array_replace($curlopts, self::CURLOPT_DEFAULT);
-				$curlopts = array_replace($curlopts, K_CURLOPTS);
+				$curlopts = array_replace($curlopts, (defined('K_CURLOPTS') ? K_CURLOPTS : []));
 				$curlopts = array_replace($curlopts, self::CURLOPT_FIXED);
 				$curlopts[CURLOPT_URL] = $url;
 				curl_setopt_array($crs, $curlopts);


### PR DESCRIPTION
## Background

This fix was identified while investigating a fatal error reported in a real-world production environment where TCPDF is vendored inside [Event Tickets Plus](https://evnt.is/et-plus) (a WordPress plugin by StellarWP) alongside [WooCommerce PDF Vouchers](https://www.wpwebelite.com/product/woocommerce-pdf-vouchers/).

The affected flow:
1. An event with a WooCommerce ticket is created
2. A customer places an order
3. An admin attempts to generate a PDF voucher from the backend
4. TCPDF crashes with a fatal before any PDF is produced

The workaround that unblocked the affected site was to manually define `K_CURLOPTS` before TCPDF executes. This PR makes that workaround unnecessary by fixing the root cause in TCPDF itself.

## Problem

When TCPDF is used as a vendored dependency with `K_TCPDF_EXTERNAL_CONFIG` set to `true`, the entire `tcpdf_config.php` is skipped. If the external config does not define `K_CURLOPTS`, PHP 8+ throws a fatal error at runtime:

```
Fatal error: Uncaught Error: Undefined constant "K_CURLOPTS"
in include/tcpdf_static.php:1860

Stack trace:
#0 tcpdf_static.php(1901): TCPDF_STATIC::url_exists()
#1 tcpdf.php(24747): TCPDF_STATIC::file_exists()
#2 tcpdf.php(6962): TCPDF->fileExists()
...
```

The guard added in `tcpdf_autoconfig.php` (commit aab43ab) does not cover this scenario — when `K_TCPDF_EXTERNAL_CONFIG` is `true`, `tcpdf_autoconfig.php` constants are also bypassed, so `K_CURLOPTS` may never be defined before it is used.

## Fix

Added a `defined()` check at the two points of use inside `include/tcpdf_static.php` — in `url_exists()` and `fileGetContents()` — so that `K_CURLOPTS` falls back to an empty array when not defined, preserving the existing `CURLOPT_DEFAULT` defaults:

```php
// Before
$curlopts = array_replace($curlopts, K_CURLOPTS);

// After
$curlopts = array_replace($curlopts, (defined('K_CURLOPTS') ? K_CURLOPTS : []));
```

This is the correct place for the guard: defensive at the point of use, guaranteed to execute regardless of which configuration path was taken.

## Why not fix it in `tcpdf_config.php` or `tcpdf_autoconfig.php`?

Both of those files are entirely skipped when `K_TCPDF_EXTERNAL_CONFIG` is `true`, which is a common pattern for projects that vendor TCPDF and supply their own configuration. The only reliable place to handle a missing `K_CURLOPTS` is where it is consumed.

## Changes

- `include/tcpdf_static.php`: 2 lines changed (lines 1860 and 1995) — one in `url_exists()`, one in `fileGetContents()`